### PR TITLE
Add support for settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+APP_TITLE=Fluxton
 APP_URL=fluxton.io
 APP_ENV=development
 DATABASE_HOST=fluxton_db

--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -25,6 +25,7 @@ func runSeeders() {
 	log.Info().Msg("Database seeding started")
 
 	seedersToRun := []func(*do.Injector){
+		seeders.SeedSettings,
 		seeders.SeedUsers,
 	}
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -57,7 +57,7 @@ func registerRoutes(e *echo.Echo, container *do.Injector) {
 	userRepo := do.MustInvoke[*repositories.UserRepository](container)
 
 	authMiddleware := middlewares.AuthMiddleware(userRepo)
-	formEnabledMiddleware := middlewares.FormEnabledMiddleware(settingService)
+	formEnabledMiddleware := middlewares.AllowFormMiddleware(settingService)
 
 	requestLogRepo := do.MustInvoke[*repositories.RequestLogRepository](container)
 	requestLogMiddleware := middlewares.RequestLoggerMiddleware(requestLogRepo)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -4,6 +4,7 @@ import (
 	"fluxton/middlewares"
 	"fluxton/repositories"
 	"fluxton/routes"
+	"fluxton/services"
 	"fmt"
 	"github.com/getsentry/sentry-go"
 	sentryecho "github.com/getsentry/sentry-go/echo"
@@ -52,8 +53,11 @@ func setupServer(container *do.Injector) *echo.Echo {
 }
 
 func registerRoutes(e *echo.Echo, container *do.Injector) {
+	settingService := do.MustInvoke[services.SettingService](container)
 	userRepo := do.MustInvoke[*repositories.UserRepository](container)
+
 	authMiddleware := middlewares.AuthMiddleware(userRepo)
+	formEnabledMiddleware := middlewares.FormEnabledMiddleware(settingService)
 
 	requestLogRepo := do.MustInvoke[*repositories.RequestLogRepository](container)
 	requestLogMiddleware := middlewares.RequestLoggerMiddleware(requestLogRepo)
@@ -64,7 +68,7 @@ func registerRoutes(e *echo.Echo, container *do.Injector) {
 	routes.RegisterOrganizationRoutes(e, container, authMiddleware)
 	routes.RegisterProjectRoutes(e, container, authMiddleware)
 	routes.RegisterTableRoutes(e, container, authMiddleware)
-	routes.RegisterFormRoutes(e, container, authMiddleware)
+	routes.RegisterFormRoutes(e, container, authMiddleware, formEnabledMiddleware)
 	routes.RegisterStorageRoutes(e, container, authMiddleware)
 	routes.RegisterFunctionRoutes(e, container, authMiddleware)
 	routes.RegisterBackup(e, container, authMiddleware)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -57,7 +57,9 @@ func registerRoutes(e *echo.Echo, container *do.Injector) {
 	userRepo := do.MustInvoke[*repositories.UserRepository](container)
 
 	authMiddleware := middlewares.AuthMiddleware(userRepo)
-	formEnabledMiddleware := middlewares.AllowFormMiddleware(settingService)
+	allowFormMiddleware := middlewares.AllowFormMiddleware(settingService)
+	allowStorageMiddleware := middlewares.AllowStorageMiddleware(settingService)
+	allowBackupMiddleware := middlewares.AllowBackupMiddleware(settingService)
 
 	requestLogRepo := do.MustInvoke[*repositories.RequestLogRepository](container)
 	requestLogMiddleware := middlewares.RequestLoggerMiddleware(requestLogRepo)
@@ -68,10 +70,10 @@ func registerRoutes(e *echo.Echo, container *do.Injector) {
 	routes.RegisterOrganizationRoutes(e, container, authMiddleware)
 	routes.RegisterProjectRoutes(e, container, authMiddleware)
 	routes.RegisterTableRoutes(e, container, authMiddleware)
-	routes.RegisterFormRoutes(e, container, authMiddleware, formEnabledMiddleware)
-	routes.RegisterStorageRoutes(e, container, authMiddleware)
+	routes.RegisterFormRoutes(e, container, authMiddleware, allowFormMiddleware)
+	routes.RegisterStorageRoutes(e, container, authMiddleware, allowStorageMiddleware)
 	routes.RegisterFunctionRoutes(e, container, authMiddleware)
-	routes.RegisterBackup(e, container, authMiddleware)
+	routes.RegisterBackup(e, container, authMiddleware, allowBackupMiddleware)
 
 	e.GET("/docs/*", echoSwagger.WrapHandler)
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -57,6 +57,7 @@ func registerRoutes(e *echo.Echo, container *do.Injector) {
 	userRepo := do.MustInvoke[*repositories.UserRepository](container)
 
 	authMiddleware := middlewares.AuthMiddleware(userRepo)
+	allowProjectMiddleware := middlewares.AllowProjectMiddleware(settingService)
 	allowFormMiddleware := middlewares.AllowFormMiddleware(settingService)
 	allowStorageMiddleware := middlewares.AllowStorageMiddleware(settingService)
 	allowBackupMiddleware := middlewares.AllowBackupMiddleware(settingService)
@@ -68,7 +69,7 @@ func registerRoutes(e *echo.Echo, container *do.Injector) {
 	routes.RegisterUserRoutes(e, container, authMiddleware)
 	routes.RegisterAdminRoutes(e, container, authMiddleware)
 	routes.RegisterOrganizationRoutes(e, container, authMiddleware)
-	routes.RegisterProjectRoutes(e, container, authMiddleware)
+	routes.RegisterProjectRoutes(e, container, authMiddleware, allowProjectMiddleware)
 	routes.RegisterTableRoutes(e, container, authMiddleware)
 	routes.RegisterFormRoutes(e, container, authMiddleware, allowFormMiddleware)
 	routes.RegisterStorageRoutes(e, container, authMiddleware, allowStorageMiddleware)

--- a/controllers/setting_controller.go
+++ b/controllers/setting_controller.go
@@ -21,9 +21,7 @@ func NewSettingController(injector *do.Injector) (*SettingController, error) {
 }
 
 func (sc *SettingController) List(c echo.Context) error {
-	authUser, _ := utils.NewAuth(c).User()
-
-	settings, err := sc.settingService.List(authUser)
+	settings, err := sc.settingService.List()
 	if err != nil {
 		return responses.ErrorResponse(c, err)
 	}

--- a/database/migrations/20250117084028_add_settings_table.sql
+++ b/database/migrations/20250117084028_add_settings_table.sql
@@ -8,15 +8,6 @@ CREATE TABLE fluxton.settings (
    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-
-INSERT INTO fluxton.settings (name, value, default_value)
-VALUES
-    ('title', 'Fluxton', 'Fluxton'),
-    ('description', 'Fluxton is a BAAS', 'Fluxton is a BAAS'),
-    ('url', 'https://fluxton.com', 'https://fluxton.com'),
-    ('allow_registration', 'true', 'true'),
-    ('max_projects_per_user', '10', '10');
-
 -- +goose StatementEnd
 
 -- +goose Down

--- a/database/seeders/seed_settings.go
+++ b/database/seeders/seed_settings.go
@@ -34,7 +34,7 @@ func SeedSettings(container *do.Injector) {
 		// API throttle settings
 		{Name: "apiThrottleLimit", Value: "100", DefaultValue: "100"},
 		{Name: "apiThrottleInterval", Value: "60", DefaultValue: "60"},
-		{Name: "apiThrottleEnabled", Value: "yes", DefaultValue: "no"},
+		{Name: "enableApiThrottle", Value: "yes", DefaultValue: "no"},
 	}
 
 	_, err := settingsService.CreateMany(settings)

--- a/database/seeders/seed_settings.go
+++ b/database/seeders/seed_settings.go
@@ -21,7 +21,7 @@ func SeedSettings(container *do.Injector) {
 		{Name: "jwtSecret", Value: os.Getenv("JWT_SECRET"), DefaultValue: os.Getenv("JWT_SECRET")},
 		{Name: "maxProjectsPerOrg", Value: "10", DefaultValue: "10"},
 		{Name: "allowRegistrations", Value: "yes", DefaultValue: "yes"},
-		{Name: "allowNewProjects", Value: "yes", DefaultValue: "yes"},
+		{Name: "allowProjects", Value: "yes", DefaultValue: "yes"},
 		{Name: "allowForms", Value: "yes", DefaultValue: "yes"},
 		{Name: "allowStorage", Value: "yes", DefaultValue: "yes"},
 		{Name: "allowBackups", Value: "yes", DefaultValue: "yes"},

--- a/database/seeders/seed_settings.go
+++ b/database/seeders/seed_settings.go
@@ -1,0 +1,49 @@
+package seeders
+
+import (
+	"fluxton/models"
+	"fluxton/repositories"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/samber/do"
+	"os"
+)
+
+func SeedSettings(container *do.Injector) {
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+
+	settingsService := do.MustInvoke[*repositories.SettingRepository](container)
+
+	settings := []models.Setting{
+		// General settings
+		{Name: "appTitle", Value: os.Getenv("APP_TITLE"), DefaultValue: os.Getenv("APP_TITLE")},
+		{Name: "appUrl", Value: os.Getenv("APP_URL"), DefaultValue: os.Getenv("APP_URL")},
+		{Name: "jwtSecret", Value: os.Getenv("JWT_SECRET"), DefaultValue: os.Getenv("JWT_SECRET")},
+		{Name: "maxProjectsPerOrg", Value: "10", DefaultValue: "10"},
+		{Name: "allowRegistrations", Value: "yes", DefaultValue: "yes"},
+		{Name: "allowNewProjects", Value: "yes", DefaultValue: "yes"},
+		{Name: "enableForms", Value: "yes", DefaultValue: "yes"},
+		{Name: "enableStorage", Value: "yes", DefaultValue: "yes"},
+		{Name: "enableBackups", Value: "yes", DefaultValue: "yes"},
+
+		// Storage settings
+		{Name: "storageMaxBuckets", Value: "10", DefaultValue: "10"},
+		{Name: "storageMaxFileSizeInKB", Value: "1024", DefaultValue: "1024"},
+		{Name: "storageAllowedMimes", Value: "jpg,png,pdf", DefaultValue: "jpg,png,pdf"},
+
+		// API throttle settings
+		{Name: "apiThrottleLimit", Value: "100", DefaultValue: "100"},
+		{Name: "apiThrottleInterval", Value: "60", DefaultValue: "60"},
+		{Name: "apiThrottleEnabled", Value: "yes", DefaultValue: "no"},
+	}
+
+	_, err := settingsService.CreateMany(settings)
+	if err != nil {
+		log.Error().
+			Str("error", err.Error()).
+			Msg("Error creating settings")
+		return
+	}
+
+	log.Info().Msg("Settings seeded successfully")
+}

--- a/database/seeders/seed_settings.go
+++ b/database/seeders/seed_settings.go
@@ -22,9 +22,9 @@ func SeedSettings(container *do.Injector) {
 		{Name: "maxProjectsPerOrg", Value: "10", DefaultValue: "10"},
 		{Name: "allowRegistrations", Value: "yes", DefaultValue: "yes"},
 		{Name: "allowNewProjects", Value: "yes", DefaultValue: "yes"},
-		{Name: "enableForms", Value: "yes", DefaultValue: "yes"},
-		{Name: "enableStorage", Value: "yes", DefaultValue: "yes"},
-		{Name: "enableBackups", Value: "yes", DefaultValue: "yes"},
+		{Name: "allowForms", Value: "yes", DefaultValue: "yes"},
+		{Name: "allowStorage", Value: "yes", DefaultValue: "yes"},
+		{Name: "allowBackups", Value: "yes", DefaultValue: "yes"},
 
 		// Storage settings
 		{Name: "storageMaxBuckets", Value: "10", DefaultValue: "10"},
@@ -34,7 +34,7 @@ func SeedSettings(container *do.Injector) {
 		// API throttle settings
 		{Name: "apiThrottleLimit", Value: "100", DefaultValue: "100"},
 		{Name: "apiThrottleInterval", Value: "60", DefaultValue: "60"},
-		{Name: "enableApiThrottle", Value: "yes", DefaultValue: "no"},
+		{Name: "allowApiThrottle", Value: "yes", DefaultValue: "no"},
 	}
 
 	_, err := settingsService.CreateMany(settings)

--- a/message/message.go
+++ b/message/message.go
@@ -16,6 +16,7 @@ var messages = map[string]string{
 	"user.error.invalidPayload":        "Invalid payload provided",
 	"user.error.emailAlreadyExists":    "User with this email already exists",
 	"user.error.usernameAlreadyExists": "User with this username already exists",
+	"user.error.registrationDisabled":  "User registration is disabled",
 
 	// Organizations
 	"organization.error.userNotFound":        "User not found in organization",

--- a/message/message.go
+++ b/message/message.go
@@ -85,7 +85,7 @@ var messages = map[string]string{
 	"form.error.updateForbidden": "You don't have permission to update this form",
 	"form.error.deleteForbidden": "You don't have permission to delete this form",
 	"form.error.duplicateName":   "Form name already exists",
-	"form.error.formsDisabled":   "Forms are disabled at the moment",
+	"form.error.disabled":        "Forms are disabled at the moment",
 
 	// Form Responses
 	"formResponse.error.notFound":             "Form response not found",

--- a/message/message.go
+++ b/message/message.go
@@ -16,7 +16,7 @@ var messages = map[string]string{
 	"user.error.invalidPayload":        "Invalid payload provided",
 	"user.error.emailAlreadyExists":    "User with this email already exists",
 	"user.error.usernameAlreadyExists": "User with this username already exists",
-	"user.error.registrationDisabled":  "User registration is disabled",
+	"user.error.registrationDisabled":  "User registration is disabled at the moment",
 
 	// Organizations
 	"organization.error.userNotFound":        "User not found in organization",
@@ -85,6 +85,7 @@ var messages = map[string]string{
 	"form.error.updateForbidden": "You don't have permission to update this form",
 	"form.error.deleteForbidden": "You don't have permission to delete this form",
 	"form.error.duplicateName":   "Form name already exists",
+	"form.error.formsDisabled":   "Forms are disabled at the moment",
 
 	// Form Responses
 	"formResponse.error.notFound":             "Form response not found",

--- a/middlewares/allow_backup_middleware.go
+++ b/middlewares/allow_backup_middleware.go
@@ -1,0 +1,19 @@
+package middlewares
+
+import (
+	"fluxton/responses"
+	"fluxton/services"
+	"github.com/labstack/echo/v4"
+)
+
+func AllowBackupMiddleware(settingService services.SettingService) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if !settingService.GetBool("allowBackup") {
+				return responses.ForbiddenResponse(c, "backup.error.disabled")
+			}
+
+			return next(c)
+		}
+	}
+}

--- a/middlewares/allow_form_middleware.go
+++ b/middlewares/allow_form_middleware.go
@@ -6,10 +6,10 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func FormEnabledMiddleware(settingService services.SettingService) echo.MiddlewareFunc {
+func AllowFormMiddleware(settingService services.SettingService) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			if err := settingService.ValidateFormsEnabled(); err != nil {
+			if !settingService.GetBool("allowForm") {
 				return responses.ForbiddenResponse(c, "form.error.disabled")
 			}
 

--- a/middlewares/allow_project_middleware.go
+++ b/middlewares/allow_project_middleware.go
@@ -1,0 +1,19 @@
+package middlewares
+
+import (
+	"fluxton/responses"
+	"fluxton/services"
+	"github.com/labstack/echo/v4"
+)
+
+func AllowProjectMiddleware(settingService services.SettingService) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if !settingService.GetBool("allowNewProject") {
+				return responses.ForbiddenResponse(c, "project.error.disabled")
+			}
+
+			return next(c)
+		}
+	}
+}

--- a/middlewares/allow_project_middleware.go
+++ b/middlewares/allow_project_middleware.go
@@ -9,7 +9,7 @@ import (
 func AllowProjectMiddleware(settingService services.SettingService) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			if !settingService.GetBool("allowNewProject") {
+			if !settingService.GetBool("allowProjects") {
 				return responses.ForbiddenResponse(c, "project.error.disabled")
 			}
 

--- a/middlewares/allow_storage_middleware.go
+++ b/middlewares/allow_storage_middleware.go
@@ -1,0 +1,19 @@
+package middlewares
+
+import (
+	"fluxton/responses"
+	"fluxton/services"
+	"github.com/labstack/echo/v4"
+)
+
+func AllowStorageMiddleware(settingService services.SettingService) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if !settingService.GetBool("allowStorage") {
+				return responses.ForbiddenResponse(c, "storage.error.disabled")
+			}
+
+			return next(c)
+		}
+	}
+}

--- a/middlewares/form_toggle_middleware.go
+++ b/middlewares/form_toggle_middleware.go
@@ -1,0 +1,19 @@
+package middlewares
+
+import (
+	"fluxton/responses"
+	"fluxton/services"
+	"github.com/labstack/echo/v4"
+)
+
+func FormEnabledMiddleware(settingService services.SettingService) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if err := settingService.ValidateFormsEnabled(); err != nil {
+				return responses.ForbiddenResponse(c, "form.error.disabled")
+			}
+
+			return next(c)
+		}
+	}
+}

--- a/middlewares/request_logger_middleware.go
+++ b/middlewares/request_logger_middleware.go
@@ -54,6 +54,7 @@ func readBody(body io.ReadCloser) string {
 	if err != nil {
 		log.Warn().
 			Str("action", constants.ActionAPIRequest).
+			Str("error", err.Error()).
 			Msg("Failed to read request body")
 
 		return ""

--- a/middlewares/request_logger_middleware.go
+++ b/middlewares/request_logger_middleware.go
@@ -5,10 +5,8 @@ import (
 	"fluxton/models"
 	"fluxton/repositories"
 	"fluxton/utils"
-	"fmt"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
-	_ "github.com/lib/pq" // PostgreSQL driver
 	"github.com/rs/zerolog/log"
 	"io"
 	"time"
@@ -54,7 +52,9 @@ func readBody(body io.ReadCloser) string {
 	defer body.Close()
 	data, err := io.ReadAll(body)
 	if err != nil {
-		fmt.Printf("failed to read request body: %v", err)
+		log.Warn().
+			Str("action", constants.ActionAPIRequest).
+			Msg("Failed to read request body")
 
 		return ""
 	}

--- a/repositories/setting_repository.go
+++ b/repositories/setting_repository.go
@@ -5,20 +5,38 @@ import (
 	"fluxton/utils"
 	"fmt"
 	"github.com/jmoiron/sqlx"
+	"github.com/rs/zerolog/log"
 	"github.com/samber/do"
+	"strings"
+	"sync"
 )
 
 type SettingRepository struct {
-	db *sqlx.DB
+	db             *sqlx.DB
+	cachedSettings []models.Setting
+	mu             sync.RWMutex
 }
 
 func NewSettingRepository(injector *do.Injector) (*SettingRepository, error) {
 	db := do.MustInvoke[*sqlx.DB](injector)
-
 	return &SettingRepository{db: db}, nil
 }
 
 func (r *SettingRepository) List() ([]models.Setting, error) {
+	r.mu.RLock()
+	if r.cachedSettings != nil {
+		settings := make([]models.Setting, len(r.cachedSettings))
+		copy(settings, r.cachedSettings) // so app doesn't modify the cached settings
+
+		r.mu.RUnlock()
+
+		log.Info().Msg("Returning cached settings")
+		return settings, nil
+	}
+
+	r.mu.RUnlock()
+
+	log.Info().Msg("Fetching settings from database")
 	query := "SELECT * FROM fluxton.settings;"
 
 	var settings []models.Setting
@@ -27,7 +45,36 @@ func (r *SettingRepository) List() ([]models.Setting, error) {
 		return nil, utils.FormatError(err, "select", utils.GetMethodName())
 	}
 
+	r.mu.Lock()
+	r.cachedSettings = settings
+	r.mu.Unlock()
+
 	return settings, nil
+}
+
+func (r *SettingRepository) CreateMany(settings []models.Setting) (bool, error) {
+	var valuePlaceholders []string
+	var args []interface{}
+
+	for i, setting := range settings {
+		placeholder := fmt.Sprintf("($%d, $%d, $%d)", 3*i+1, 3*i+2, 3*i+3)
+		valuePlaceholders = append(valuePlaceholders, placeholder)
+		args = append(args, setting.Name, setting.Value, setting.DefaultValue)
+	}
+
+	query := fmt.Sprintf("INSERT INTO fluxton.settings (name, value, default_value) VALUES %s;",
+		strings.Join(valuePlaceholders, ", "))
+
+	_, err := r.db.Exec(query, args...)
+	if err != nil {
+		return false, fmt.Errorf("could not create settings: %v", err)
+	}
+
+	r.mu.Lock()
+	r.cachedSettings = nil
+	r.mu.Unlock()
+
+	return true, nil
 }
 
 func (r *SettingRepository) Update(settings []models.Setting) (bool, error) {
@@ -49,6 +96,10 @@ func (r *SettingRepository) Update(settings []models.Setting) (bool, error) {
 	if err != nil {
 		return false, utils.FormatError(err, "transactionCommit", utils.GetMethodName())
 	}
+
+	r.mu.Lock()
+	r.cachedSettings = nil
+	r.mu.Unlock()
 
 	return true, nil
 }

--- a/repositories/setting_repository.go
+++ b/repositories/setting_repository.go
@@ -5,7 +5,6 @@ import (
 	"fluxton/utils"
 	"fmt"
 	"github.com/jmoiron/sqlx"
-	"github.com/rs/zerolog/log"
 	"github.com/samber/do"
 	"strings"
 	"sync"
@@ -30,13 +29,11 @@ func (r *SettingRepository) List() ([]models.Setting, error) {
 
 		r.mu.RUnlock()
 
-		log.Info().Msg("Returning cached settings")
 		return settings, nil
 	}
 
 	r.mu.RUnlock()
 
-	log.Info().Msg("Fetching settings from database")
 	query := "SELECT * FROM fluxton.settings;"
 
 	var settings []models.Setting

--- a/routes/backup_routes.go
+++ b/routes/backup_routes.go
@@ -6,10 +6,10 @@ import (
 	"github.com/samber/do"
 )
 
-func RegisterBackup(e *echo.Echo, container *do.Injector, authMiddleware echo.MiddlewareFunc) {
+func RegisterBackup(e *echo.Echo, container *do.Injector, authMiddleware echo.MiddlewareFunc, allowBackupMiddleware echo.MiddlewareFunc) {
 	backupController := do.MustInvoke[*controllers.BackupController](container)
 
-	formsGroup := e.Group("api/backups", authMiddleware)
+	formsGroup := e.Group("api/backups", authMiddleware, allowBackupMiddleware)
 
 	formsGroup.POST("", backupController.Store)
 	formsGroup.GET("", backupController.List)

--- a/routes/form_routes.go
+++ b/routes/form_routes.go
@@ -6,12 +6,17 @@ import (
 	"github.com/samber/do"
 )
 
-func RegisterFormRoutes(e *echo.Echo, container *do.Injector, authMiddleware echo.MiddlewareFunc) {
+func RegisterFormRoutes(
+	e *echo.Echo,
+	container *do.Injector,
+	authMiddleware echo.MiddlewareFunc,
+	formEnabledMiddleware echo.MiddlewareFunc,
+) {
 	formController := do.MustInvoke[*controllers.FormController](container)
 	formFieldController := do.MustInvoke[*controllers.FormFieldController](container)
 	formResponseController := do.MustInvoke[*controllers.FormResponseController](container)
 
-	formsGroup := e.Group("api/forms", authMiddleware)
+	formsGroup := e.Group("api/forms", authMiddleware, formEnabledMiddleware)
 
 	formsGroup.POST("", formController.Store)
 	formsGroup.GET("", formController.List)
@@ -20,7 +25,7 @@ func RegisterFormRoutes(e *echo.Echo, container *do.Injector, authMiddleware ech
 	formsGroup.DELETE("/:formUUID", formController.Delete)
 
 	// Form Field routes
-	formFieldsGroup := e.Group("api/forms/:formUUID/fields", authMiddleware)
+	formFieldsGroup := e.Group("api/forms/:formUUID/fields", authMiddleware, formEnabledMiddleware)
 
 	formFieldsGroup.POST("", formFieldController.Store)
 	formFieldsGroup.GET("", formFieldController.List)
@@ -29,7 +34,7 @@ func RegisterFormRoutes(e *echo.Echo, container *do.Injector, authMiddleware ech
 	formFieldsGroup.DELETE("/:fieldUUID", formFieldController.Delete)
 
 	// Form Response routes
-	formResponsesGroup := e.Group("api/forms/:formUUID/responses", authMiddleware)
+	formResponsesGroup := e.Group("api/forms/:formUUID/responses", authMiddleware, formEnabledMiddleware)
 
 	formResponsesGroup.GET("", formResponseController.List)
 	formResponsesGroup.POST("", formResponseController.Store)

--- a/routes/project_routes.go
+++ b/routes/project_routes.go
@@ -6,10 +6,10 @@ import (
 	"github.com/samber/do"
 )
 
-func RegisterProjectRoutes(e *echo.Echo, container *do.Injector, authMiddleware echo.MiddlewareFunc) {
+func RegisterProjectRoutes(e *echo.Echo, container *do.Injector, authMiddleware echo.MiddlewareFunc, allowProjectMiddleware echo.MiddlewareFunc) {
 	projectController := do.MustInvoke[*controllers.ProjectController](container)
 
-	projectsGroup := e.Group("api/projects", authMiddleware)
+	projectsGroup := e.Group("api/projects", authMiddleware, allowProjectMiddleware)
 
 	projectsGroup.POST("", projectController.Store)
 	projectsGroup.GET("", projectController.List)

--- a/routes/storage_routes.go
+++ b/routes/storage_routes.go
@@ -6,11 +6,11 @@ import (
 	"github.com/samber/do"
 )
 
-func RegisterStorageRoutes(e *echo.Echo, container *do.Injector, authMiddleware echo.MiddlewareFunc) {
+func RegisterStorageRoutes(e *echo.Echo, container *do.Injector, authMiddleware echo.MiddlewareFunc, allowStorageMiddleware echo.MiddlewareFunc) {
 	bucketController := do.MustInvoke[*controllers.BucketController](container)
 	fileController := do.MustInvoke[*controllers.FileController](container)
 
-	projectsGroup := e.Group("api/buckets", authMiddleware)
+	projectsGroup := e.Group("api/buckets", authMiddleware, allowStorageMiddleware)
 
 	projectsGroup.POST("", bucketController.Store)
 	projectsGroup.GET("", bucketController.List)

--- a/services/form_service.go
+++ b/services/form_service.go
@@ -43,8 +43,7 @@ func NewFormService(injector *do.Injector) (FormService, error) {
 }
 
 func (s *FormServiceImpl) List(paginationParams requests.PaginationParams, projectUUID uuid.UUID, authUser models.AuthUser) ([]models.Form, error) {
-	err := s.validateFormsEnabled()
-	if err != nil {
+	if err := s.validateFormsEnabled(); err != nil {
 		return []models.Form{}, err
 	}
 
@@ -61,8 +60,7 @@ func (s *FormServiceImpl) List(paginationParams requests.PaginationParams, proje
 }
 
 func (s *FormServiceImpl) GetByUUID(formUUID uuid.UUID, authUser models.AuthUser) (models.Form, error) {
-	err := s.validateFormsEnabled()
-	if err != nil {
+	if err := s.validateFormsEnabled(); err != nil {
 		return models.Form{}, err
 	}
 
@@ -84,8 +82,7 @@ func (s *FormServiceImpl) GetByUUID(formUUID uuid.UUID, authUser models.AuthUser
 }
 
 func (s *FormServiceImpl) Create(request *form_requests.CreateRequest, authUser models.AuthUser) (models.Form, error) {
-	err := s.validateFormsEnabled()
-	if err != nil {
+	if err := s.validateFormsEnabled(); err != nil {
 		return models.Form{}, err
 	}
 
@@ -121,8 +118,7 @@ func (s *FormServiceImpl) Create(request *form_requests.CreateRequest, authUser 
 }
 
 func (s *FormServiceImpl) Update(formUUID uuid.UUID, authUser models.AuthUser, request *form_requests.CreateRequest) (*models.Form, error) {
-	err := s.validateFormsEnabled()
-	if err != nil {
+	if err := s.validateFormsEnabled(); err != nil {
 		return &models.Form{}, err
 	}
 
@@ -157,8 +153,7 @@ func (s *FormServiceImpl) Update(formUUID uuid.UUID, authUser models.AuthUser, r
 }
 
 func (s *FormServiceImpl) Delete(formUUID uuid.UUID, authUser models.AuthUser) (bool, error) {
-	err := s.validateFormsEnabled()
-	if err != nil {
+	if err := s.validateFormsEnabled(); err != nil {
 		return false, err
 	}
 

--- a/services/form_service.go
+++ b/services/form_service.go
@@ -22,31 +22,24 @@ type FormService interface {
 }
 
 type FormServiceImpl struct {
-	projectPolicy  *policies.ProjectPolicy
-	settingService SettingService
-	formRepo       *repositories.FormRepository
-	projectRepo    *repositories.ProjectRepository
+	projectPolicy *policies.ProjectPolicy
+	formRepo      *repositories.FormRepository
+	projectRepo   *repositories.ProjectRepository
 }
 
 func NewFormService(injector *do.Injector) (FormService, error) {
 	policy := do.MustInvoke[*policies.ProjectPolicy](injector)
-	settingService := do.MustInvoke[SettingService](injector)
 	formRepo := do.MustInvoke[*repositories.FormRepository](injector)
 	projectRepo := do.MustInvoke[*repositories.ProjectRepository](injector)
 
 	return &FormServiceImpl{
-		projectPolicy:  policy,
-		settingService: settingService,
-		formRepo:       formRepo,
-		projectRepo:    projectRepo,
+		projectPolicy: policy,
+		formRepo:      formRepo,
+		projectRepo:   projectRepo,
 	}, nil
 }
 
 func (s *FormServiceImpl) List(paginationParams requests.PaginationParams, projectUUID uuid.UUID, authUser models.AuthUser) ([]models.Form, error) {
-	if err := s.validateFormsEnabled(); err != nil {
-		return nil, err
-	}
-
 	organizationUUID, err := s.projectRepo.GetOrganizationUUIDByProjectUUID(projectUUID)
 	if err != nil {
 		return nil, err
@@ -60,10 +53,6 @@ func (s *FormServiceImpl) List(paginationParams requests.PaginationParams, proje
 }
 
 func (s *FormServiceImpl) GetByUUID(formUUID uuid.UUID, authUser models.AuthUser) (models.Form, error) {
-	if err := s.validateFormsEnabled(); err != nil {
-		return models.Form{}, err
-	}
-
 	form, err := s.formRepo.GetByUUID(formUUID)
 	if err != nil {
 		return models.Form{}, err
@@ -82,10 +71,6 @@ func (s *FormServiceImpl) GetByUUID(formUUID uuid.UUID, authUser models.AuthUser
 }
 
 func (s *FormServiceImpl) Create(request *form_requests.CreateRequest, authUser models.AuthUser) (models.Form, error) {
-	if err := s.validateFormsEnabled(); err != nil {
-		return models.Form{}, err
-	}
-
 	organizationUUID, err := s.projectRepo.GetOrganizationUUIDByProjectUUID(request.ProjectUUID)
 	if err != nil {
 		return models.Form{}, err
@@ -118,10 +103,6 @@ func (s *FormServiceImpl) Create(request *form_requests.CreateRequest, authUser 
 }
 
 func (s *FormServiceImpl) Update(formUUID uuid.UUID, authUser models.AuthUser, request *form_requests.CreateRequest) (*models.Form, error) {
-	if err := s.validateFormsEnabled(); err != nil {
-		return &models.Form{}, err
-	}
-
 	form, err := s.formRepo.GetByUUID(formUUID)
 	if err != nil {
 		return nil, err
@@ -153,10 +134,6 @@ func (s *FormServiceImpl) Update(formUUID uuid.UUID, authUser models.AuthUser, r
 }
 
 func (s *FormServiceImpl) Delete(formUUID uuid.UUID, authUser models.AuthUser) (bool, error) {
-	if err := s.validateFormsEnabled(); err != nil {
-		return false, err
-	}
-
 	form, err := s.formRepo.GetByUUID(formUUID)
 	if err != nil {
 		return false, err
@@ -182,15 +159,6 @@ func (s *FormServiceImpl) validateNameForDuplication(name string, projectUUID uu
 
 	if exists {
 		return errs.NewUnprocessableError("form.error.duplicateName")
-	}
-
-	return nil
-}
-
-func (s *FormServiceImpl) validateFormsEnabled() error {
-	enabled := s.settingService.GetBool("enableForms")
-	if !enabled {
-		return errs.NewForbiddenError("form.error.formsDisabled")
 	}
 
 	return nil

--- a/services/form_service.go
+++ b/services/form_service.go
@@ -44,16 +44,16 @@ func NewFormService(injector *do.Injector) (FormService, error) {
 
 func (s *FormServiceImpl) List(paginationParams requests.PaginationParams, projectUUID uuid.UUID, authUser models.AuthUser) ([]models.Form, error) {
 	if err := s.validateFormsEnabled(); err != nil {
-		return []models.Form{}, err
+		return nil, err
 	}
 
 	organizationUUID, err := s.projectRepo.GetOrganizationUUIDByProjectUUID(projectUUID)
 	if err != nil {
-		return []models.Form{}, err
+		return nil, err
 	}
 
 	if !s.projectPolicy.CanAccess(organizationUUID, authUser) {
-		return []models.Form{}, errs.NewForbiddenError("form.error.listForbidden")
+		return nil, errs.NewForbiddenError("form.error.listForbidden")
 	}
 
 	return s.formRepo.ListForProject(paginationParams, projectUUID)

--- a/services/form_service.go
+++ b/services/form_service.go
@@ -193,7 +193,7 @@ func (s *FormServiceImpl) validateNameForDuplication(name string, projectUUID uu
 }
 
 func (s *FormServiceImpl) validateFormsEnabled() error {
-	enabled := s.settingService.IsEnabled("enableForms")
+	enabled := s.settingService.GetBool("enableForms")
 	if !enabled {
 		return errs.NewForbiddenError("form.error.formsDisabled")
 	}

--- a/services/setting_service.go
+++ b/services/setting_service.go
@@ -88,11 +88,7 @@ func (s *SettingServiceImpl) ValidateEnabled(settingName, errorKey string) error
 }
 
 func (s *SettingServiceImpl) ValidateFormsEnabled() error {
-	log.Info().Msg("IN HERE")
-	x := s.ValidateEnabled("enableForms", "form.error.disabled")
-	log.Info().Msg(x.Error())
-	log.Info().Msg("OUT HERE")
-	return x
+	return s.ValidateEnabled("allowForms", "form.error.disabled")
 }
 
 func (s *SettingServiceImpl) ValidateNewProjectsEnabled() error {
@@ -104,7 +100,7 @@ func (s *SettingServiceImpl) ValidateStorageEnabled() error {
 }
 
 func (s *SettingServiceImpl) ValidateBackupsEnabled() error {
-	return s.ValidateEnabled("enableBackups", "backup.error.disabled")
+	return s.ValidateEnabled("allowBackups", "backup.error.disabled")
 }
 
 func (s *SettingServiceImpl) Update(authUser models.AuthUser, request *requests.SettingUpdateRequest) ([]models.Setting, error) {

--- a/services/setting_service.go
+++ b/services/setting_service.go
@@ -18,10 +18,6 @@ type SettingService interface {
 	GetBool(name string) bool
 	Update(authUser models.AuthUser, request *requests.SettingUpdateRequest) ([]models.Setting, error)
 	Reset(authUser models.AuthUser) ([]models.Setting, error)
-	ValidateFormsEnabled() error
-	ValidateNewProjectsEnabled() error
-	ValidateStorageEnabled() error
-	ValidateBackupsEnabled() error
 }
 
 type SettingServiceImpl struct {
@@ -77,30 +73,6 @@ func (s *SettingServiceImpl) GetBool(name string) bool {
 	setting := s.Get(name)
 
 	return setting.Value == "yes"
-}
-
-func (s *SettingServiceImpl) ValidateEnabled(settingName, errorKey string) error {
-	if !s.GetBool(settingName) {
-		return errs.NewForbiddenError(errorKey)
-	}
-
-	return nil
-}
-
-func (s *SettingServiceImpl) ValidateFormsEnabled() error {
-	return s.ValidateEnabled("allowForms", "form.error.disabled")
-}
-
-func (s *SettingServiceImpl) ValidateNewProjectsEnabled() error {
-	return s.ValidateEnabled("allowNewProjects", "project.error.disabled")
-}
-
-func (s *SettingServiceImpl) ValidateStorageEnabled() error {
-	return s.ValidateEnabled("enableStorage", "storage.error.disabled")
-}
-
-func (s *SettingServiceImpl) ValidateBackupsEnabled() error {
-	return s.ValidateEnabled("allowBackups", "backup.error.disabled")
 }
 
 func (s *SettingServiceImpl) Update(authUser models.AuthUser, request *requests.SettingUpdateRequest) ([]models.Setting, error) {

--- a/services/setting_service.go
+++ b/services/setting_service.go
@@ -18,6 +18,10 @@ type SettingService interface {
 	GetBool(name string) bool
 	Update(authUser models.AuthUser, request *requests.SettingUpdateRequest) ([]models.Setting, error)
 	Reset(authUser models.AuthUser) ([]models.Setting, error)
+	ValidateFormsEnabled() error
+	ValidateNewProjectsEnabled() error
+	ValidateStorageEnabled() error
+	ValidateBackupsEnabled() error
 }
 
 type SettingServiceImpl struct {
@@ -73,6 +77,34 @@ func (s *SettingServiceImpl) GetBool(name string) bool {
 	setting := s.Get(name)
 
 	return setting.Value == "yes"
+}
+
+func (s *SettingServiceImpl) ValidateEnabled(settingName, errorKey string) error {
+	if !s.GetBool(settingName) {
+		return errs.NewForbiddenError(errorKey)
+	}
+
+	return nil
+}
+
+func (s *SettingServiceImpl) ValidateFormsEnabled() error {
+	log.Info().Msg("IN HERE")
+	x := s.ValidateEnabled("enableForms", "form.error.disabled")
+	log.Info().Msg(x.Error())
+	log.Info().Msg("OUT HERE")
+	return x
+}
+
+func (s *SettingServiceImpl) ValidateNewProjectsEnabled() error {
+	return s.ValidateEnabled("allowNewProjects", "project.error.disabled")
+}
+
+func (s *SettingServiceImpl) ValidateStorageEnabled() error {
+	return s.ValidateEnabled("enableStorage", "storage.error.disabled")
+}
+
+func (s *SettingServiceImpl) ValidateBackupsEnabled() error {
+	return s.ValidateEnabled("enableBackups", "backup.error.disabled")
 }
 
 func (s *SettingServiceImpl) Update(authUser models.AuthUser, request *requests.SettingUpdateRequest) ([]models.Setting, error) {

--- a/services/setting_service.go
+++ b/services/setting_service.go
@@ -15,6 +15,7 @@ type SettingService interface {
 	List() ([]models.Setting, error)
 	Get(name string) models.Setting
 	GetValue(name string) string
+	IsEnabled(name string) bool
 	Update(authUser models.AuthUser, request *requests.SettingUpdateRequest) ([]models.Setting, error)
 	Reset(authUser models.AuthUser) ([]models.Setting, error)
 }
@@ -66,6 +67,12 @@ func (s *SettingServiceImpl) GetValue(name string) string {
 	setting := s.Get(name)
 
 	return setting.Value
+}
+
+func (s *SettingServiceImpl) IsEnabled(name string) bool {
+	setting := s.Get(name)
+
+	return setting.Value == "yes"
 }
 
 func (s *SettingServiceImpl) Update(authUser models.AuthUser, request *requests.SettingUpdateRequest) ([]models.Setting, error) {

--- a/services/setting_service.go
+++ b/services/setting_service.go
@@ -6,12 +6,15 @@ import (
 	"fluxton/policies"
 	"fluxton/repositories"
 	"fluxton/requests"
+	"github.com/rs/zerolog/log"
 	"github.com/samber/do"
 	"time"
 )
 
 type SettingService interface {
-	List(authUser models.AuthUser) ([]models.Setting, error)
+	List() ([]models.Setting, error)
+	Get(name string) models.Setting
+	GetValue(name string) string
 	Update(authUser models.AuthUser, request *requests.SettingUpdateRequest) ([]models.Setting, error)
 	Reset(authUser models.AuthUser) ([]models.Setting, error)
 }
@@ -34,12 +37,35 @@ func NewSettingService(injector *do.Injector) (SettingService, error) {
 	}, nil
 }
 
-func (s *SettingServiceImpl) List(authUser models.AuthUser) ([]models.Setting, error) {
-	if !s.adminPolicy.CanAccess(authUser) {
-		return []models.Setting{}, errs.NewForbiddenError("setting.error.listForbidden")
+func (s *SettingServiceImpl) List() ([]models.Setting, error) {
+	return s.settingRepo.List()
+}
+
+func (s *SettingServiceImpl) Get(name string) models.Setting {
+	settings, err := s.settingRepo.List() // cached settings so no need to worry about multiple calls
+	if err != nil {
+		log.Error().
+			Str("error", err.Error()).
+			Msg("Error fetching settings")
 	}
 
-	return s.settingRepo.List()
+	for _, setting := range settings {
+		if setting.Name == name {
+			return setting
+		}
+	}
+
+	log.Error().
+		Str("name", name).
+		Msg("Setting not found")
+
+	return models.Setting{}
+}
+
+func (s *SettingServiceImpl) GetValue(name string) string {
+	setting := s.Get(name)
+
+	return setting.Value
 }
 
 func (s *SettingServiceImpl) Update(authUser models.AuthUser, request *requests.SettingUpdateRequest) ([]models.Setting, error) {

--- a/services/setting_service.go
+++ b/services/setting_service.go
@@ -15,7 +15,7 @@ type SettingService interface {
 	List() ([]models.Setting, error)
 	Get(name string) models.Setting
 	GetValue(name string) string
-	IsEnabled(name string) bool
+	GetBool(name string) bool
 	Update(authUser models.AuthUser, request *requests.SettingUpdateRequest) ([]models.Setting, error)
 	Reset(authUser models.AuthUser) ([]models.Setting, error)
 }
@@ -69,7 +69,7 @@ func (s *SettingServiceImpl) GetValue(name string) string {
 	return setting.Value
 }
 
-func (s *SettingServiceImpl) IsEnabled(name string) bool {
+func (s *SettingServiceImpl) GetBool(name string) bool {
 	setting := s.Get(name)
 
 	return setting.Value == "yes"

--- a/services/user_service.go
+++ b/services/user_service.go
@@ -87,7 +87,7 @@ func (s *UserServiceImpl) ExistsByUUID(id uuid.UUID) error {
 }
 
 func (s *UserServiceImpl) Create(request *user_requests.CreateRequest) (models.User, string, error) {
-	if !s.settingService.IsEnabled("allowRegistrations") {
+	if !s.settingService.GetBool("allowRegistrations") {
 		return models.User{}, "", errs.NewBadRequestError("user.error.registrationDisabled")
 	}
 

--- a/services/user_service.go
+++ b/services/user_service.go
@@ -28,13 +28,18 @@ type UserService interface {
 }
 
 type UserServiceImpl struct {
-	userRepo *repositories.UserRepository
+	settingService SettingService
+	userRepo       *repositories.UserRepository
 }
 
 func NewUserService(injector *do.Injector) (UserService, error) {
+	settingService := do.MustInvoke[SettingService](injector)
 	repo := do.MustInvoke[*repositories.UserRepository](injector)
 
-	return &UserServiceImpl{userRepo: repo}, nil
+	return &UserServiceImpl{
+		settingService: settingService,
+		userRepo:       repo,
+	}, nil
 }
 
 func (s *UserServiceImpl) Login(request *user_requests.LoginRequest) (models.User, string, error) {
@@ -82,6 +87,10 @@ func (s *UserServiceImpl) ExistsByUUID(id uuid.UUID) error {
 }
 
 func (s *UserServiceImpl) Create(request *user_requests.CreateRequest) (models.User, string, error) {
+	if !s.settingService.IsEnabled("allowRegistrations") {
+		return models.User{}, "", errs.NewBadRequestError("user.error.registrationDisabled")
+	}
+
 	existsByEmail, err := s.userRepo.ExistsByEmail(request.Email)
 	if err != nil {
 		return models.User{}, "", err


### PR DESCRIPTION
App is limited to `.env` settings at the moment. This has drawback. App container must be re-built for new settings to take effect. Also, you must have server access to update values. 

This PR changes that by moving settings to database and exposing them via endpoints. Users will then be able to adjust settings from their dashboard.