### PR TITLE
[Fix] Allow multiple login sessions

### DIFF
--- a/internal/api/middlewares/auth_middleware.go
+++ b/internal/api/middlewares/auth_middleware.go
@@ -51,13 +51,14 @@ func AuthMiddleware(userRepo user.Repository) echo.MiddlewareFunc {
 				return response.ErrorResponse(c, errors.NewUnauthorizedError("auth.error.tokenInvalid"))
 			}
 
-			currentJWTVersion := int(claims["version"].(float64))
-			existingJWTVersion, err := userRepo.GetJWTVersion(userUUID)
+			loggedInJWTVersion := int(claims["version"].(float64))
+			latestVersion, err := userRepo.GetJWTVersion(userUUID)
 			if err != nil {
 				return response.ErrorResponse(c, err)
 			}
 
-			if currentJWTVersion != existingJWTVersion {
+			// Allow a max 5 sessions to be active at the same time
+			if (latestVersion - loggedInJWTVersion) >= 5 {
 				return response.UnauthorizedResponse(c, "auth.error.tokenInvalid")
 			}
 

--- a/internal/api/middlewares/auth_middleware.go
+++ b/internal/api/middlewares/auth_middleware.go
@@ -2,6 +2,7 @@ package middlewares
 
 import (
 	"fluxton/internal/api/response"
+	"fluxton/internal/config/constants"
 	"fluxton/internal/domain/auth"
 	"fluxton/internal/domain/user"
 	"fluxton/pkg/errors"
@@ -58,7 +59,7 @@ func AuthMiddleware(userRepo user.Repository) echo.MiddlewareFunc {
 			}
 
 			// Allow a max 5 sessions to be active at the same time
-			if (latestVersion - loggedInJWTVersion) >= 5 {
+			if (latestVersion - loggedInJWTVersion) >= constants.UserMaxLoginSessions {
 				return response.UnauthorizedResponse(c, "auth.error.tokenInvalid")
 			}
 

--- a/internal/config/constants/user.go
+++ b/internal/config/constants/user.go
@@ -1,6 +1,8 @@
 package constants
 
 const (
+	UserMaxLoginSessions = 5
+
 	UserRoleSuperman  = 1
 	UserRoleOwner     = 2
 	UserRoleAdmin     = 3


### PR DESCRIPTION
In different cases, users might want to have multiple sessions. They may want to login from two different browsers/devices etc. This pull request allows them to have upto 5 active sessions. We previously allowed only 1.

Fixes: https://github.com/fluxton-io/fluxton/issues/23