### PR TITLE
[FLX-12] [🔥 Feature] Add endpoint to list admin logs with search functionality 

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -19,6 +19,89 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/admin/logs": {
+            "get": {
+                "description": "Get all logs",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Logs"
+                ],
+                "summary": "List all logs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bearer Token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Page number for pagination",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Number of items per page",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Field to sort by",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort order (asc or desc)",
+                        "name": "order",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of files",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/definitions/response.Response"
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "content": {
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/definitions/logging.Response"
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "500": {
+                        "description": "Internal server error"
+                    }
+                }
+            }
+        },
         "/backups": {
             "get": {
                 "description": "Retrieve a list of all backups for the specified project",
@@ -56,7 +139,7 @@ const docTemplate = `{
                             "items": {
                                 "allOf": [
                                     {
-                                        "$ref": "#/definitions/responses.Response"
+                                        "$ref": "#/definitions/response.Response"
                                     },
                                     {
                                         "type": "object",
@@ -64,7 +147,7 @@ const docTemplate = `{
                                             "content": {
                                                 "type": "array",
                                                 "items": {
-                                                    "$ref": "#/definitions/resources.BackupResponse"
+                                                    "$ref": "#/definitions/backup.Response"
                                                 }
                                             }
                                         }
@@ -114,7 +197,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/requests.DefaultRequestWithProjectHeader"
+                            "$ref": "#/definitions/dto.DefaultRequestWithProjectHeader"
                         }
                     }
                 ],
@@ -124,13 +207,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.BackupResponse"
+                                            "$ref": "#/definitions/backup.Response"
                                         }
                                     }
                                 }
@@ -194,13 +277,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.BackupResponse"
+                                            "$ref": "#/definitions/backup.Response"
                                         }
                                     }
                                 }
@@ -330,7 +413,7 @@ const docTemplate = `{
                             "items": {
                                 "allOf": [
                                     {
-                                        "$ref": "#/definitions/responses.Response"
+                                        "$ref": "#/definitions/response.Response"
                                     },
                                     {
                                         "type": "object",
@@ -338,7 +421,7 @@ const docTemplate = `{
                                             "content": {
                                                 "type": "array",
                                                 "items": {
-                                                    "$ref": "#/definitions/resources.FileResponse"
+                                                    "$ref": "#/definitions/file.Response"
                                                 }
                                             }
                                         }
@@ -391,7 +474,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/container_requests.CreateFileRequest"
+                            "$ref": "#/definitions/file.CreateRequest"
                         }
                     }
                 ],
@@ -401,13 +484,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FileResponse"
+                                            "$ref": "#/definitions/file.Response"
                                         }
                                     }
                                 }
@@ -468,13 +551,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FileResponse"
+                                            "$ref": "#/definitions/file.Response"
                                         }
                                     }
                                 }
@@ -584,7 +667,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/container_requests.RenameFileRequest"
+                            "$ref": "#/definitions/file.RenameRequest"
                         }
                     }
                 ],
@@ -594,13 +677,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FileResponse"
+                                            "$ref": "#/definitions/file.Response"
                                         }
                                     }
                                 }
@@ -680,7 +763,7 @@ const docTemplate = `{
                             "items": {
                                 "allOf": [
                                     {
-                                        "$ref": "#/definitions/responses.Response"
+                                        "$ref": "#/definitions/response.Response"
                                     },
                                     {
                                         "type": "object",
@@ -688,7 +771,7 @@ const docTemplate = `{
                                             "content": {
                                                 "type": "array",
                                                 "items": {
-                                                    "$ref": "#/definitions/resources.FormResponse"
+                                                    "$ref": "#/definitions/form.Response"
                                                 }
                                             }
                                         }
@@ -741,7 +824,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/form_requests.CreateRequest"
+                            "$ref": "#/definitions/form.CreateRequest"
                         }
                     }
                 ],
@@ -751,13 +834,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FormResponse"
+                                            "$ref": "#/definitions/form.Response"
                                         }
                                     }
                                 }
@@ -821,13 +904,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FormResponse"
+                                            "$ref": "#/definitions/form.Response"
                                         }
                                     }
                                 }
@@ -885,7 +968,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/form_requests.CreateRequest"
+                            "$ref": "#/definitions/form.CreateRequest"
                         }
                     }
                 ],
@@ -895,13 +978,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FormResponse"
+                                            "$ref": "#/definitions/form.Response"
                                         }
                                     }
                                 }
@@ -1010,7 +1093,7 @@ const docTemplate = `{
                             "items": {
                                 "allOf": [
                                     {
-                                        "$ref": "#/definitions/responses.Response"
+                                        "$ref": "#/definitions/response.Response"
                                     },
                                     {
                                         "type": "object",
@@ -1018,7 +1101,7 @@ const docTemplate = `{
                                             "content": {
                                                 "type": "array",
                                                 "items": {
-                                                    "$ref": "#/definitions/resources.FormFieldResponse"
+                                                    "$ref": "#/definitions/form.FieldResponseApi"
                                                 }
                                             }
                                         }
@@ -1064,7 +1147,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/form_requests.CreateFormFieldsRequest"
+                            "$ref": "#/definitions/form.CreateFormFieldsRequest"
                         }
                     },
                     {
@@ -1081,13 +1164,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FormFieldResponse"
+                                            "$ref": "#/definitions/form.FieldResponseApi"
                                         }
                                     }
                                 }
@@ -1151,13 +1234,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FormFieldResponse"
+                                            "$ref": "#/definitions/form.FieldResponseApi"
                                         }
                                     }
                                 }
@@ -1201,7 +1284,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/form_requests.UpdateFormFieldRequest"
+                            "$ref": "#/definitions/form.UpdateFormFieldRequest"
                         }
                     },
                     {
@@ -1225,13 +1308,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FormFieldResponse"
+                                            "$ref": "#/definitions/form.FieldResponseApi"
                                         }
                                     }
                                 }
@@ -1345,7 +1428,7 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -1353,7 +1436,7 @@ const docTemplate = `{
                                         "content": {
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/definitions/resources.FormResponseForAPI"
+                                                "$ref": "#/definitions/form.ResponseForAPI"
                                             }
                                         }
                                     }
@@ -1412,7 +1495,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/form_requests.CreateResponseRequest"
+                            "$ref": "#/definitions/form.CreateResponseRequest"
                         }
                     }
                 ],
@@ -1422,13 +1505,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FormResponseForAPI"
+                                            "$ref": "#/definitions/form.ResponseForAPI"
                                         }
                                     }
                                 }
@@ -1499,13 +1582,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FormResponseForAPI"
+                                            "$ref": "#/definitions/form.ResponseForAPI"
                                         }
                                     }
                                 }
@@ -1632,7 +1715,7 @@ const docTemplate = `{
                             "items": {
                                 "allOf": [
                                     {
-                                        "$ref": "#/definitions/responses.Response"
+                                        "$ref": "#/definitions/response.Response"
                                     },
                                     {
                                         "type": "object",
@@ -1640,7 +1723,7 @@ const docTemplate = `{
                                             "content": {
                                                 "type": "array",
                                                 "items": {
-                                                    "$ref": "#/definitions/resources.FunctionResponse"
+                                                    "$ref": "#/definitions/database.FunctionResponse"
                                                 }
                                             }
                                         }
@@ -1689,11 +1772,11 @@ const docTemplate = `{
                     },
                     {
                         "description": "Function details",
-                        "name": "form",
+                        "name": "function",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/requests.CreateFunctionRequest"
+                            "$ref": "#/definitions/database.CreateFunctionRequest"
                         }
                     }
                 ],
@@ -1703,13 +1786,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FunctionResponse"
+                                            "$ref": "#/definitions/database.FunctionResponse"
                                         }
                                     }
                                 }
@@ -1780,13 +1863,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FunctionResponse"
+                                            "$ref": "#/definitions/database.FunctionResponse"
                                         }
                                     }
                                 }
@@ -1921,7 +2004,7 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -1929,7 +2012,7 @@ const docTemplate = `{
                                         "content": {
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/definitions/resources.OrganizationResponse"
+                                                "$ref": "#/definitions/organization.Response"
                                             }
                                         }
                                     }
@@ -1971,7 +2054,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/organization_requests.CreateRequest"
+                            "$ref": "#/definitions/organization.CreateRequest"
                         }
                     }
                 ],
@@ -1981,13 +2064,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.OrganizationResponse"
+                                            "$ref": "#/definitions/organization.Response"
                                         }
                                     }
                                 }
@@ -2044,13 +2127,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.OrganizationResponse"
+                                            "$ref": "#/definitions/organization.Response"
                                         }
                                     }
                                 }
@@ -2104,7 +2187,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/organization_requests.CreateRequest"
+                            "$ref": "#/definitions/organization.CreateRequest"
                         }
                     }
                 ],
@@ -2114,13 +2197,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.OrganizationResponse"
+                                            "$ref": "#/definitions/organization.Response"
                                         }
                                     }
                                 }
@@ -2173,7 +2256,7 @@ const docTemplate = `{
                     "204": {
                         "description": "Organization deleted",
                         "schema": {
-                            "$ref": "#/definitions/responses.Response"
+                            "$ref": "#/definitions/response.Response"
                         }
                     },
                     "401": {
@@ -2220,7 +2303,7 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -2228,7 +2311,7 @@ const docTemplate = `{
                                         "content": {
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/definitions/resources.UserResponse"
+                                                "$ref": "#/definitions/user.Response"
                                             }
                                         }
                                     }
@@ -2283,7 +2366,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/organization_requests.MemberCreateRequest"
+                            "$ref": "#/definitions/organization.MemberCreateRequest"
                         }
                     }
                 ],
@@ -2293,13 +2376,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.UserResponse"
+                                            "$ref": "#/definitions/user.Response"
                                         }
                                     }
                                 }
@@ -2435,7 +2518,7 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -2443,7 +2526,7 @@ const docTemplate = `{
                                         "content": {
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/definitions/resources.ProjectResponse"
+                                                "$ref": "#/definitions/project.Response"
                                             }
                                         }
                                     }
@@ -2495,7 +2578,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/project_requests.CreateRequest"
+                            "$ref": "#/definitions/project.CreateRequest"
                         }
                     }
                 ],
@@ -2505,13 +2588,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.ProjectResponse"
+                                            "$ref": "#/definitions/project.Response"
                                         }
                                     }
                                 }
@@ -2568,13 +2651,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.ProjectResponse"
+                                            "$ref": "#/definitions/project.Response"
                                         }
                                     }
                                 }
@@ -2628,7 +2711,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/project_requests.UpdateRequest"
+                            "$ref": "#/definitions/project.UpdateRequest"
                         }
                     }
                 ],
@@ -2638,13 +2721,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.ProjectResponse"
+                                            "$ref": "#/definitions/project.Response"
                                         }
                                     }
                                 }
@@ -2697,7 +2780,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Project deleted",
                         "schema": {
-                            "$ref": "#/definitions/responses.Response"
+                            "$ref": "#/definitions/response.Response"
                         }
                     },
                     "400": {
@@ -2771,7 +2854,7 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -2779,7 +2862,7 @@ const docTemplate = `{
                                         "content": {
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/definitions/resources.ContainerResponse"
+                                                "$ref": "#/definitions/container.Response"
                                             }
                                         }
                                     }
@@ -2831,7 +2914,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/container_requests.CreateRequest"
+                            "$ref": "#/definitions/container.CreateRequest"
                         }
                     }
                 ],
@@ -2841,13 +2924,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.ContainerResponse"
+                                            "$ref": "#/definitions/container.Response"
                                         }
                                     }
                                 }
@@ -2911,13 +2994,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.ContainerResponse"
+                                            "$ref": "#/definitions/container.Response"
                                         }
                                     }
                                 }
@@ -2978,7 +3061,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/container_requests.CreateRequest"
+                            "$ref": "#/definitions/container.CreateRequest"
                         }
                     }
                 ],
@@ -2988,13 +3071,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.ContainerResponse"
+                                            "$ref": "#/definitions/container.Response"
                                         }
                                     }
                                 }
@@ -3101,7 +3184,7 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -3109,7 +3192,7 @@ const docTemplate = `{
                                         "content": {
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/definitions/resources.TableResponse"
+                                                "$ref": "#/definitions/database.TableResponse"
                                             }
                                         }
                                     }
@@ -3161,7 +3244,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/table_requests.CreateRequest"
+                            "$ref": "#/definitions/database.CreateTableRequest"
                         }
                     }
                 ],
@@ -3171,13 +3254,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.TableResponse"
+                                            "$ref": "#/definitions/database.TableResponse"
                                         }
                                     }
                                 }
@@ -3233,7 +3316,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/table_requests.UploadRequest"
+                            "$ref": "#/definitions/database.UploadTableRequest"
                         }
                     }
                 ],
@@ -3243,13 +3326,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.TableResponse"
+                                            "$ref": "#/definitions/database.TableResponse"
                                         }
                                     }
                                 }
@@ -3306,7 +3389,7 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -3314,7 +3397,7 @@ const docTemplate = `{
                                         "content": {
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/definitions/resources.ColumnResponse"
+                                                "$ref": "#/definitions/database.ColumnResponse"
                                             }
                                         }
                                     }
@@ -3373,7 +3456,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/column_requests.CreateRequest"
+                            "$ref": "#/definitions/database.CreateColumnRequest"
                         }
                     }
                 ],
@@ -3383,13 +3466,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.TableResponse"
+                                            "$ref": "#/definitions/database.ColumnResponse"
                                         }
                                     }
                                 }
@@ -3450,7 +3533,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/column_requests.CreateRequest"
+                            "$ref": "#/definitions/database.CreateColumnRequest"
                         }
                     }
                 ],
@@ -3460,13 +3543,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.TableResponse"
+                                            "$ref": "#/definitions/database.ColumnResponse"
                                         }
                                     }
                                 }
@@ -3536,7 +3619,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/column_requests.RenameRequest"
+                            "$ref": "#/definitions/database.RenameColumnRequest"
                         }
                     }
                 ],
@@ -3544,7 +3627,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Column renamed",
                         "schema": {
-                            "$ref": "#/definitions/responses.Response"
+                            "$ref": "#/definitions/response.Response"
                         }
                     },
                     "400": {
@@ -3664,13 +3747,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.TableResponse"
+                                            "$ref": "#/definitions/database.TableResponse"
                                         }
                                     }
                                 }
@@ -3786,7 +3869,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/table_requests.RenameRequest"
+                            "$ref": "#/definitions/database.RenameTableRequest"
                         }
                     }
                 ],
@@ -3796,13 +3879,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.TableResponse"
+                                            "$ref": "#/definitions/database.TableResponse"
                                         }
                                     }
                                 }
@@ -3859,7 +3942,7 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -3917,7 +4000,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/requests.IndexCreateRequest"
+                            "$ref": "#/definitions/database.CreateIndexRequest"
                         }
                     }
                 ],
@@ -3927,7 +4010,7 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -3995,7 +4078,7 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -4115,7 +4198,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/table_requests.RenameRequest"
+                            "$ref": "#/definitions/database.RenameTableRequest"
                         }
                     }
                 ],
@@ -4125,13 +4208,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.TableResponse"
+                                            "$ref": "#/definitions/database.TableResponse"
                                         }
                                     }
                                 }
@@ -4173,7 +4256,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/user_requests.CreateRequest"
+                            "$ref": "#/definitions/user.CreateRequest"
                         }
                     }
                 ],
@@ -4183,13 +4266,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.UserResponse"
+                                            "$ref": "#/definitions/user.Response"
                                         }
                                     }
                                 }
@@ -4228,7 +4311,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/user_requests.LoginRequest"
+                            "$ref": "#/definitions/user.LoginRequest"
                         }
                     }
                 ],
@@ -4238,13 +4321,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.UserResponse"
+                                            "$ref": "#/definitions/user.Response"
                                         }
                                     }
                                 }
@@ -4289,7 +4372,7 @@ const docTemplate = `{
                     "200": {
                         "description": "User logged out",
                         "schema": {
-                            "$ref": "#/definitions/responses.Response"
+                            "$ref": "#/definitions/response.Response"
                         }
                     },
                     "400": {
@@ -4339,13 +4422,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.UserResponse"
+                                            "$ref": "#/definitions/user.Response"
                                         }
                                     }
                                 }
@@ -4396,7 +4479,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/user_requests.UpdateRequest"
+                            "$ref": "#/definitions/user.UpdateRequest"
                         }
                     }
                 ],
@@ -4406,13 +4489,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.UserResponse"
+                                            "$ref": "#/definitions/user.Response"
                                         }
                                     }
                                 }
@@ -4436,55 +4519,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "column_requests.CreateRequest": {
-            "type": "object"
-        },
-        "column_requests.RenameRequest": {
-            "type": "object"
-        },
-        "container_requests.CreateFileRequest": {
-            "type": "object"
-        },
-        "container_requests.CreateRequest": {
-            "type": "object"
-        },
-        "container_requests.RenameFileRequest": {
-            "type": "object"
-        },
-        "form_requests.CreateFormFieldsRequest": {
-            "type": "object"
-        },
-        "form_requests.CreateRequest": {
-            "type": "object"
-        },
-        "form_requests.CreateResponseRequest": {
-            "type": "object"
-        },
-        "form_requests.UpdateFormFieldRequest": {
-            "type": "object"
-        },
-        "organization_requests.CreateRequest": {
-            "type": "object"
-        },
-        "organization_requests.MemberCreateRequest": {
-            "type": "object"
-        },
-        "project_requests.CreateRequest": {
-            "type": "object"
-        },
-        "project_requests.UpdateRequest": {
-            "type": "object"
-        },
-        "requests.CreateFunctionRequest": {
-            "type": "object"
-        },
-        "requests.DefaultRequestWithProjectHeader": {
-            "type": "object"
-        },
-        "requests.IndexCreateRequest": {
-            "type": "object"
-        },
-        "resources.BackupResponse": {
+        "backup.Response": {
             "type": "object",
             "properties": {
                 "completedAt": {
@@ -4507,42 +4542,27 @@ const docTemplate = `{
                 }
             }
         },
-        "resources.ColumnResponse": {
+        "container.CreateRequest": {
             "type": "object",
             "properties": {
-                "defaultValue": {
+                "description": {
                     "type": "string"
                 },
-                "foreign": {
+                "is_public": {
                     "type": "boolean"
+                },
+                "max_file_size": {
+                    "type": "integer"
                 },
                 "name": {
                     "type": "string"
                 },
-                "notNull": {
-                    "type": "boolean"
-                },
-                "position": {
-                    "type": "integer"
-                },
-                "primary": {
-                    "type": "boolean"
-                },
-                "referenceColumn": {
+                "projectUUID": {
                     "type": "string"
-                },
-                "referenceTable": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
-                },
-                "unique": {
-                    "type": "boolean"
                 }
             }
         },
-        "resources.ContainerResponse": {
+        "container.Response": {
             "type": "object",
             "properties": {
                 "createdAt": {
@@ -4583,7 +4603,197 @@ const docTemplate = `{
                 }
             }
         },
-        "resources.FileResponse": {
+        "database.ColumnResponse": {
+            "type": "object",
+            "properties": {
+                "defaultValue": {
+                    "type": "string"
+                },
+                "foreign": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "notNull": {
+                    "type": "boolean"
+                },
+                "position": {
+                    "type": "integer"
+                },
+                "primary": {
+                    "type": "boolean"
+                },
+                "referenceColumn": {
+                    "type": "string"
+                },
+                "referenceTable": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "unique": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "database.CreateColumnRequest": {
+            "type": "object"
+        },
+        "database.CreateFunctionRequest": {
+            "type": "object",
+            "properties": {
+                "definition": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "parameters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/database.functionParameter"
+                    }
+                },
+                "projectUUID": {
+                    "type": "string"
+                },
+                "return_type": {
+                    "type": "string"
+                }
+            }
+        },
+        "database.CreateIndexRequest": {
+            "type": "object",
+            "properties": {
+                "columns": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "is_unique": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "database.CreateTableRequest": {
+            "type": "object"
+        },
+        "database.FunctionResponse": {
+            "type": "object",
+            "properties": {
+                "dataType": {
+                    "type": "string"
+                },
+                "definition": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "database.RenameColumnRequest": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "database.RenameTableRequest": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "database.TableResponse": {
+            "type": "object",
+            "properties": {
+                "estimatedRows": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "totalSize": {
+                    "type": "string"
+                }
+            }
+        },
+        "database.UploadTableRequest": {
+            "type": "object"
+        },
+        "database.functionParameter": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.DefaultRequestWithProjectHeader": {
+            "type": "object",
+            "properties": {
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "file.CreateRequest": {
+            "type": "object",
+            "properties": {
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "file.RenameRequest": {
+            "type": "object",
+            "properties": {
+                "full_file_name": {
+                    "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "file.Response": {
             "type": "object",
             "properties": {
                 "containerUuid": {
@@ -4616,7 +4826,100 @@ const docTemplate = `{
                 }
             }
         },
-        "resources.FormFieldResponse": {
+        "form.CreateFormFieldsRequest": {
+            "type": "object",
+            "properties": {
+                "fields": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/form.FieldRequest"
+                    }
+                },
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "form.CreateRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "form.CreateResponseRequest": {
+            "type": "object",
+            "properties": {
+                "projectUUID": {
+                    "type": "string"
+                },
+                "response": {
+                    "type": "object",
+                    "additionalProperties": true
+                }
+            }
+        },
+        "form.FieldRequest": {
+            "type": "object",
+            "properties": {
+                "date_format": {
+                    "description": "fails if provided and field value doesn't match",
+                    "type": "string"
+                },
+                "default_value": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "end_date": {
+                    "type": "string"
+                },
+                "is_required": {
+                    "type": "boolean"
+                },
+                "label": {
+                    "description": "required fields",
+                    "type": "string"
+                },
+                "max_length": {
+                    "type": "integer"
+                },
+                "max_value": {
+                    "type": "integer"
+                },
+                "min_length": {
+                    "description": "all fields from this point are optional",
+                    "type": "integer"
+                },
+                "min_value": {
+                    "description": "only applicable for number types",
+                    "type": "integer"
+                },
+                "options": {
+                    "description": "Options for select/radio types",
+                    "type": "string"
+                },
+                "pattern": {
+                    "type": "string"
+                },
+                "start_date": {
+                    "description": "only applicable for date types",
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "form.FieldResponseApi": {
             "type": "object",
             "properties": {
                 "createdAt": {
@@ -4675,7 +4978,7 @@ const docTemplate = `{
                 }
             }
         },
-        "resources.FormFieldResponseForAPI": {
+        "form.FieldResponseForAPI": {
             "type": "object",
             "properties": {
                 "createdAt": {
@@ -4698,7 +5001,7 @@ const docTemplate = `{
                 }
             }
         },
-        "resources.FormResponse": {
+        "form.Response": {
             "type": "object",
             "properties": {
                 "createdAt": {
@@ -4727,7 +5030,7 @@ const docTemplate = `{
                 }
             }
         },
-        "resources.FormResponseForAPI": {
+        "form.ResponseForAPI": {
             "type": "object",
             "properties": {
                 "formUuid": {
@@ -4736,7 +5039,7 @@ const docTemplate = `{
                 "responses": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/resources.FormFieldResponseForAPI"
+                        "$ref": "#/definitions/form.FieldResponseForAPI"
                     }
                 },
                 "uuid": {
@@ -4744,19 +5047,55 @@ const docTemplate = `{
                 }
             }
         },
-        "resources.FunctionResponse": {
+        "form.UpdateFormFieldRequest": {
             "type": "object",
             "properties": {
-                "dataType": {
+                "date_format": {
+                    "description": "fails if provided and field value doesn't match",
                     "type": "string"
                 },
-                "definition": {
+                "default_value": {
                     "type": "string"
                 },
-                "language": {
+                "description": {
                     "type": "string"
                 },
-                "name": {
+                "end_date": {
+                    "type": "string"
+                },
+                "is_required": {
+                    "type": "boolean"
+                },
+                "label": {
+                    "description": "required fields",
+                    "type": "string"
+                },
+                "max_length": {
+                    "type": "integer"
+                },
+                "max_value": {
+                    "type": "integer"
+                },
+                "min_length": {
+                    "description": "all fields from this point are optional",
+                    "type": "integer"
+                },
+                "min_value": {
+                    "description": "only applicable for number types",
+                    "type": "integer"
+                },
+                "options": {
+                    "description": "Options for select/radio types",
+                    "type": "string"
+                },
+                "pattern": {
+                    "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
+                },
+                "start_date": {
+                    "description": "only applicable for date types",
                     "type": "string"
                 },
                 "type": {
@@ -4764,7 +5103,64 @@ const docTemplate = `{
                 }
             }
         },
-        "resources.OrganizationResponse": {
+        "logging.Response": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "endpoint": {
+                    "type": "string"
+                },
+                "ipAddress": {
+                    "type": "string"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "integer"
+                },
+                "userAgent": {
+                    "type": "string"
+                },
+                "userUuid": {
+                    "type": "string"
+                },
+                "uuid": {
+                    "type": "string"
+                }
+            }
+        },
+        "organization.CreateRequest": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "organization.MemberCreateRequest": {
+            "type": "object",
+            "properties": {
+                "projectUUID": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "organization.Response": {
             "type": "object",
             "properties": {
                 "createdAt": {
@@ -4787,7 +5183,24 @@ const docTemplate = `{
                 }
             }
         },
-        "resources.ProjectResponse": {
+        "project.CreateRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "organization_uuid": {
+                    "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "project.Response": {
             "type": "object",
             "properties": {
                 "createdAt": {
@@ -4822,27 +5235,70 @@ const docTemplate = `{
                 }
             }
         },
-        "resources.TableResponse": {
+        "project.UpdateRequest": {
             "type": "object",
             "properties": {
-                "estimatedRows": {
-                    "type": "integer"
-                },
-                "id": {
-                    "type": "integer"
+                "description": {
+                    "type": "string"
                 },
                 "name": {
                     "type": "string"
                 },
-                "schema": {
-                    "type": "string"
-                },
-                "totalSize": {
+                "projectUUID": {
                     "type": "string"
                 }
             }
         },
-        "resources.UserResponse": {
+        "response.Response": {
+            "type": "object",
+            "properties": {
+                "content": {},
+                "errors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "user.CreateRequest": {
+            "type": "object",
+            "properties": {
+                "bio": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "user.LoginRequest": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "user.Response": {
             "type": "object",
             "properties": {
                 "bio": {
@@ -4871,38 +5327,16 @@ const docTemplate = `{
                 }
             }
         },
-        "responses.Response": {
+        "user.UpdateRequest": {
             "type": "object",
             "properties": {
-                "content": {},
-                "errors": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                "bio": {
+                    "type": "string"
                 },
-                "success": {
-                    "type": "boolean"
+                "projectUUID": {
+                    "type": "string"
                 }
             }
-        },
-        "table_requests.CreateRequest": {
-            "type": "object"
-        },
-        "table_requests.RenameRequest": {
-            "type": "object"
-        },
-        "table_requests.UploadRequest": {
-            "type": "object"
-        },
-        "user_requests.CreateRequest": {
-            "type": "object"
-        },
-        "user_requests.LoginRequest": {
-            "type": "object"
-        },
-        "user_requests.UpdateRequest": {
-            "type": "object"
         }
     }
 }`

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -13,6 +13,89 @@
     "host": "fluxton.io/api",
     "basePath": "/v2",
     "paths": {
+        "/admin/logs": {
+            "get": {
+                "description": "Get all logs",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Logs"
+                ],
+                "summary": "List all logs",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bearer Token",
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Page number for pagination",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Number of items per page",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Field to sort by",
+                        "name": "sort",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort order (asc or desc)",
+                        "name": "order",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of files",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/definitions/response.Response"
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "content": {
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/definitions/logging.Response"
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid input"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "500": {
+                        "description": "Internal server error"
+                    }
+                }
+            }
+        },
         "/backups": {
             "get": {
                 "description": "Retrieve a list of all backups for the specified project",
@@ -50,7 +133,7 @@
                             "items": {
                                 "allOf": [
                                     {
-                                        "$ref": "#/definitions/responses.Response"
+                                        "$ref": "#/definitions/response.Response"
                                     },
                                     {
                                         "type": "object",
@@ -58,7 +141,7 @@
                                             "content": {
                                                 "type": "array",
                                                 "items": {
-                                                    "$ref": "#/definitions/resources.BackupResponse"
+                                                    "$ref": "#/definitions/backup.Response"
                                                 }
                                             }
                                         }
@@ -108,7 +191,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/requests.DefaultRequestWithProjectHeader"
+                            "$ref": "#/definitions/dto.DefaultRequestWithProjectHeader"
                         }
                     }
                 ],
@@ -118,13 +201,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.BackupResponse"
+                                            "$ref": "#/definitions/backup.Response"
                                         }
                                     }
                                 }
@@ -188,13 +271,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.BackupResponse"
+                                            "$ref": "#/definitions/backup.Response"
                                         }
                                     }
                                 }
@@ -324,7 +407,7 @@
                             "items": {
                                 "allOf": [
                                     {
-                                        "$ref": "#/definitions/responses.Response"
+                                        "$ref": "#/definitions/response.Response"
                                     },
                                     {
                                         "type": "object",
@@ -332,7 +415,7 @@
                                             "content": {
                                                 "type": "array",
                                                 "items": {
-                                                    "$ref": "#/definitions/resources.FileResponse"
+                                                    "$ref": "#/definitions/file.Response"
                                                 }
                                             }
                                         }
@@ -385,7 +468,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/container_requests.CreateFileRequest"
+                            "$ref": "#/definitions/file.CreateRequest"
                         }
                     }
                 ],
@@ -395,13 +478,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FileResponse"
+                                            "$ref": "#/definitions/file.Response"
                                         }
                                     }
                                 }
@@ -462,13 +545,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FileResponse"
+                                            "$ref": "#/definitions/file.Response"
                                         }
                                     }
                                 }
@@ -578,7 +661,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/container_requests.RenameFileRequest"
+                            "$ref": "#/definitions/file.RenameRequest"
                         }
                     }
                 ],
@@ -588,13 +671,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FileResponse"
+                                            "$ref": "#/definitions/file.Response"
                                         }
                                     }
                                 }
@@ -674,7 +757,7 @@
                             "items": {
                                 "allOf": [
                                     {
-                                        "$ref": "#/definitions/responses.Response"
+                                        "$ref": "#/definitions/response.Response"
                                     },
                                     {
                                         "type": "object",
@@ -682,7 +765,7 @@
                                             "content": {
                                                 "type": "array",
                                                 "items": {
-                                                    "$ref": "#/definitions/resources.FormResponse"
+                                                    "$ref": "#/definitions/form.Response"
                                                 }
                                             }
                                         }
@@ -735,7 +818,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/form_requests.CreateRequest"
+                            "$ref": "#/definitions/form.CreateRequest"
                         }
                     }
                 ],
@@ -745,13 +828,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FormResponse"
+                                            "$ref": "#/definitions/form.Response"
                                         }
                                     }
                                 }
@@ -815,13 +898,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FormResponse"
+                                            "$ref": "#/definitions/form.Response"
                                         }
                                     }
                                 }
@@ -879,7 +962,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/form_requests.CreateRequest"
+                            "$ref": "#/definitions/form.CreateRequest"
                         }
                     }
                 ],
@@ -889,13 +972,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FormResponse"
+                                            "$ref": "#/definitions/form.Response"
                                         }
                                     }
                                 }
@@ -1004,7 +1087,7 @@
                             "items": {
                                 "allOf": [
                                     {
-                                        "$ref": "#/definitions/responses.Response"
+                                        "$ref": "#/definitions/response.Response"
                                     },
                                     {
                                         "type": "object",
@@ -1012,7 +1095,7 @@
                                             "content": {
                                                 "type": "array",
                                                 "items": {
-                                                    "$ref": "#/definitions/resources.FormFieldResponse"
+                                                    "$ref": "#/definitions/form.FieldResponseApi"
                                                 }
                                             }
                                         }
@@ -1058,7 +1141,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/form_requests.CreateFormFieldsRequest"
+                            "$ref": "#/definitions/form.CreateFormFieldsRequest"
                         }
                     },
                     {
@@ -1075,13 +1158,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FormFieldResponse"
+                                            "$ref": "#/definitions/form.FieldResponseApi"
                                         }
                                     }
                                 }
@@ -1145,13 +1228,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FormFieldResponse"
+                                            "$ref": "#/definitions/form.FieldResponseApi"
                                         }
                                     }
                                 }
@@ -1195,7 +1278,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/form_requests.UpdateFormFieldRequest"
+                            "$ref": "#/definitions/form.UpdateFormFieldRequest"
                         }
                     },
                     {
@@ -1219,13 +1302,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FormFieldResponse"
+                                            "$ref": "#/definitions/form.FieldResponseApi"
                                         }
                                     }
                                 }
@@ -1339,7 +1422,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -1347,7 +1430,7 @@
                                         "content": {
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/definitions/resources.FormResponseForAPI"
+                                                "$ref": "#/definitions/form.ResponseForAPI"
                                             }
                                         }
                                     }
@@ -1406,7 +1489,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/form_requests.CreateResponseRequest"
+                            "$ref": "#/definitions/form.CreateResponseRequest"
                         }
                     }
                 ],
@@ -1416,13 +1499,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FormResponseForAPI"
+                                            "$ref": "#/definitions/form.ResponseForAPI"
                                         }
                                     }
                                 }
@@ -1493,13 +1576,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FormResponseForAPI"
+                                            "$ref": "#/definitions/form.ResponseForAPI"
                                         }
                                     }
                                 }
@@ -1626,7 +1709,7 @@
                             "items": {
                                 "allOf": [
                                     {
-                                        "$ref": "#/definitions/responses.Response"
+                                        "$ref": "#/definitions/response.Response"
                                     },
                                     {
                                         "type": "object",
@@ -1634,7 +1717,7 @@
                                             "content": {
                                                 "type": "array",
                                                 "items": {
-                                                    "$ref": "#/definitions/resources.FunctionResponse"
+                                                    "$ref": "#/definitions/database.FunctionResponse"
                                                 }
                                             }
                                         }
@@ -1683,11 +1766,11 @@
                     },
                     {
                         "description": "Function details",
-                        "name": "form",
+                        "name": "function",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/requests.CreateFunctionRequest"
+                            "$ref": "#/definitions/database.CreateFunctionRequest"
                         }
                     }
                 ],
@@ -1697,13 +1780,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FunctionResponse"
+                                            "$ref": "#/definitions/database.FunctionResponse"
                                         }
                                     }
                                 }
@@ -1774,13 +1857,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.FunctionResponse"
+                                            "$ref": "#/definitions/database.FunctionResponse"
                                         }
                                     }
                                 }
@@ -1915,7 +1998,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -1923,7 +2006,7 @@
                                         "content": {
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/definitions/resources.OrganizationResponse"
+                                                "$ref": "#/definitions/organization.Response"
                                             }
                                         }
                                     }
@@ -1965,7 +2048,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/organization_requests.CreateRequest"
+                            "$ref": "#/definitions/organization.CreateRequest"
                         }
                     }
                 ],
@@ -1975,13 +2058,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.OrganizationResponse"
+                                            "$ref": "#/definitions/organization.Response"
                                         }
                                     }
                                 }
@@ -2038,13 +2121,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.OrganizationResponse"
+                                            "$ref": "#/definitions/organization.Response"
                                         }
                                     }
                                 }
@@ -2098,7 +2181,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/organization_requests.CreateRequest"
+                            "$ref": "#/definitions/organization.CreateRequest"
                         }
                     }
                 ],
@@ -2108,13 +2191,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.OrganizationResponse"
+                                            "$ref": "#/definitions/organization.Response"
                                         }
                                     }
                                 }
@@ -2167,7 +2250,7 @@
                     "204": {
                         "description": "Organization deleted",
                         "schema": {
-                            "$ref": "#/definitions/responses.Response"
+                            "$ref": "#/definitions/response.Response"
                         }
                     },
                     "401": {
@@ -2214,7 +2297,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -2222,7 +2305,7 @@
                                         "content": {
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/definitions/resources.UserResponse"
+                                                "$ref": "#/definitions/user.Response"
                                             }
                                         }
                                     }
@@ -2277,7 +2360,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/organization_requests.MemberCreateRequest"
+                            "$ref": "#/definitions/organization.MemberCreateRequest"
                         }
                     }
                 ],
@@ -2287,13 +2370,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.UserResponse"
+                                            "$ref": "#/definitions/user.Response"
                                         }
                                     }
                                 }
@@ -2429,7 +2512,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -2437,7 +2520,7 @@
                                         "content": {
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/definitions/resources.ProjectResponse"
+                                                "$ref": "#/definitions/project.Response"
                                             }
                                         }
                                     }
@@ -2489,7 +2572,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/project_requests.CreateRequest"
+                            "$ref": "#/definitions/project.CreateRequest"
                         }
                     }
                 ],
@@ -2499,13 +2582,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.ProjectResponse"
+                                            "$ref": "#/definitions/project.Response"
                                         }
                                     }
                                 }
@@ -2562,13 +2645,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.ProjectResponse"
+                                            "$ref": "#/definitions/project.Response"
                                         }
                                     }
                                 }
@@ -2622,7 +2705,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/project_requests.UpdateRequest"
+                            "$ref": "#/definitions/project.UpdateRequest"
                         }
                     }
                 ],
@@ -2632,13 +2715,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.ProjectResponse"
+                                            "$ref": "#/definitions/project.Response"
                                         }
                                     }
                                 }
@@ -2691,7 +2774,7 @@
                     "200": {
                         "description": "Project deleted",
                         "schema": {
-                            "$ref": "#/definitions/responses.Response"
+                            "$ref": "#/definitions/response.Response"
                         }
                     },
                     "400": {
@@ -2765,7 +2848,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -2773,7 +2856,7 @@
                                         "content": {
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/definitions/resources.ContainerResponse"
+                                                "$ref": "#/definitions/container.Response"
                                             }
                                         }
                                     }
@@ -2825,7 +2908,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/container_requests.CreateRequest"
+                            "$ref": "#/definitions/container.CreateRequest"
                         }
                     }
                 ],
@@ -2835,13 +2918,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.ContainerResponse"
+                                            "$ref": "#/definitions/container.Response"
                                         }
                                     }
                                 }
@@ -2905,13 +2988,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.ContainerResponse"
+                                            "$ref": "#/definitions/container.Response"
                                         }
                                     }
                                 }
@@ -2972,7 +3055,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/container_requests.CreateRequest"
+                            "$ref": "#/definitions/container.CreateRequest"
                         }
                     }
                 ],
@@ -2982,13 +3065,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.ContainerResponse"
+                                            "$ref": "#/definitions/container.Response"
                                         }
                                     }
                                 }
@@ -3095,7 +3178,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -3103,7 +3186,7 @@
                                         "content": {
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/definitions/resources.TableResponse"
+                                                "$ref": "#/definitions/database.TableResponse"
                                             }
                                         }
                                     }
@@ -3155,7 +3238,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/table_requests.CreateRequest"
+                            "$ref": "#/definitions/database.CreateTableRequest"
                         }
                     }
                 ],
@@ -3165,13 +3248,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.TableResponse"
+                                            "$ref": "#/definitions/database.TableResponse"
                                         }
                                     }
                                 }
@@ -3227,7 +3310,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/table_requests.UploadRequest"
+                            "$ref": "#/definitions/database.UploadTableRequest"
                         }
                     }
                 ],
@@ -3237,13 +3320,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.TableResponse"
+                                            "$ref": "#/definitions/database.TableResponse"
                                         }
                                     }
                                 }
@@ -3300,7 +3383,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -3308,7 +3391,7 @@
                                         "content": {
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/definitions/resources.ColumnResponse"
+                                                "$ref": "#/definitions/database.ColumnResponse"
                                             }
                                         }
                                     }
@@ -3367,7 +3450,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/column_requests.CreateRequest"
+                            "$ref": "#/definitions/database.CreateColumnRequest"
                         }
                     }
                 ],
@@ -3377,13 +3460,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.TableResponse"
+                                            "$ref": "#/definitions/database.ColumnResponse"
                                         }
                                     }
                                 }
@@ -3444,7 +3527,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/column_requests.CreateRequest"
+                            "$ref": "#/definitions/database.CreateColumnRequest"
                         }
                     }
                 ],
@@ -3454,13 +3537,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.TableResponse"
+                                            "$ref": "#/definitions/database.ColumnResponse"
                                         }
                                     }
                                 }
@@ -3530,7 +3613,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/column_requests.RenameRequest"
+                            "$ref": "#/definitions/database.RenameColumnRequest"
                         }
                     }
                 ],
@@ -3538,7 +3621,7 @@
                     "200": {
                         "description": "Column renamed",
                         "schema": {
-                            "$ref": "#/definitions/responses.Response"
+                            "$ref": "#/definitions/response.Response"
                         }
                     },
                     "400": {
@@ -3658,13 +3741,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.TableResponse"
+                                            "$ref": "#/definitions/database.TableResponse"
                                         }
                                     }
                                 }
@@ -3780,7 +3863,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/table_requests.RenameRequest"
+                            "$ref": "#/definitions/database.RenameTableRequest"
                         }
                     }
                 ],
@@ -3790,13 +3873,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.TableResponse"
+                                            "$ref": "#/definitions/database.TableResponse"
                                         }
                                     }
                                 }
@@ -3853,7 +3936,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -3911,7 +3994,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/requests.IndexCreateRequest"
+                            "$ref": "#/definitions/database.CreateIndexRequest"
                         }
                     }
                 ],
@@ -3921,7 +4004,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -3989,7 +4072,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -4109,7 +4192,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/table_requests.RenameRequest"
+                            "$ref": "#/definitions/database.RenameTableRequest"
                         }
                     }
                 ],
@@ -4119,13 +4202,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.TableResponse"
+                                            "$ref": "#/definitions/database.TableResponse"
                                         }
                                     }
                                 }
@@ -4167,7 +4250,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/user_requests.CreateRequest"
+                            "$ref": "#/definitions/user.CreateRequest"
                         }
                     }
                 ],
@@ -4177,13 +4260,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.UserResponse"
+                                            "$ref": "#/definitions/user.Response"
                                         }
                                     }
                                 }
@@ -4222,7 +4305,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/user_requests.LoginRequest"
+                            "$ref": "#/definitions/user.LoginRequest"
                         }
                     }
                 ],
@@ -4232,13 +4315,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.UserResponse"
+                                            "$ref": "#/definitions/user.Response"
                                         }
                                     }
                                 }
@@ -4283,7 +4366,7 @@
                     "200": {
                         "description": "User logged out",
                         "schema": {
-                            "$ref": "#/definitions/responses.Response"
+                            "$ref": "#/definitions/response.Response"
                         }
                     },
                     "400": {
@@ -4333,13 +4416,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.UserResponse"
+                                            "$ref": "#/definitions/user.Response"
                                         }
                                     }
                                 }
@@ -4390,7 +4473,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/user_requests.UpdateRequest"
+                            "$ref": "#/definitions/user.UpdateRequest"
                         }
                     }
                 ],
@@ -4400,13 +4483,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/responses.Response"
+                                    "$ref": "#/definitions/response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "content": {
-                                            "$ref": "#/definitions/resources.UserResponse"
+                                            "$ref": "#/definitions/user.Response"
                                         }
                                     }
                                 }
@@ -4430,55 +4513,7 @@
         }
     },
     "definitions": {
-        "column_requests.CreateRequest": {
-            "type": "object"
-        },
-        "column_requests.RenameRequest": {
-            "type": "object"
-        },
-        "container_requests.CreateFileRequest": {
-            "type": "object"
-        },
-        "container_requests.CreateRequest": {
-            "type": "object"
-        },
-        "container_requests.RenameFileRequest": {
-            "type": "object"
-        },
-        "form_requests.CreateFormFieldsRequest": {
-            "type": "object"
-        },
-        "form_requests.CreateRequest": {
-            "type": "object"
-        },
-        "form_requests.CreateResponseRequest": {
-            "type": "object"
-        },
-        "form_requests.UpdateFormFieldRequest": {
-            "type": "object"
-        },
-        "organization_requests.CreateRequest": {
-            "type": "object"
-        },
-        "organization_requests.MemberCreateRequest": {
-            "type": "object"
-        },
-        "project_requests.CreateRequest": {
-            "type": "object"
-        },
-        "project_requests.UpdateRequest": {
-            "type": "object"
-        },
-        "requests.CreateFunctionRequest": {
-            "type": "object"
-        },
-        "requests.DefaultRequestWithProjectHeader": {
-            "type": "object"
-        },
-        "requests.IndexCreateRequest": {
-            "type": "object"
-        },
-        "resources.BackupResponse": {
+        "backup.Response": {
             "type": "object",
             "properties": {
                 "completedAt": {
@@ -4501,42 +4536,27 @@
                 }
             }
         },
-        "resources.ColumnResponse": {
+        "container.CreateRequest": {
             "type": "object",
             "properties": {
-                "defaultValue": {
+                "description": {
                     "type": "string"
                 },
-                "foreign": {
+                "is_public": {
                     "type": "boolean"
+                },
+                "max_file_size": {
+                    "type": "integer"
                 },
                 "name": {
                     "type": "string"
                 },
-                "notNull": {
-                    "type": "boolean"
-                },
-                "position": {
-                    "type": "integer"
-                },
-                "primary": {
-                    "type": "boolean"
-                },
-                "referenceColumn": {
+                "projectUUID": {
                     "type": "string"
-                },
-                "referenceTable": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
-                },
-                "unique": {
-                    "type": "boolean"
                 }
             }
         },
-        "resources.ContainerResponse": {
+        "container.Response": {
             "type": "object",
             "properties": {
                 "createdAt": {
@@ -4577,7 +4597,197 @@
                 }
             }
         },
-        "resources.FileResponse": {
+        "database.ColumnResponse": {
+            "type": "object",
+            "properties": {
+                "defaultValue": {
+                    "type": "string"
+                },
+                "foreign": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "notNull": {
+                    "type": "boolean"
+                },
+                "position": {
+                    "type": "integer"
+                },
+                "primary": {
+                    "type": "boolean"
+                },
+                "referenceColumn": {
+                    "type": "string"
+                },
+                "referenceTable": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "unique": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "database.CreateColumnRequest": {
+            "type": "object"
+        },
+        "database.CreateFunctionRequest": {
+            "type": "object",
+            "properties": {
+                "definition": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "parameters": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/database.functionParameter"
+                    }
+                },
+                "projectUUID": {
+                    "type": "string"
+                },
+                "return_type": {
+                    "type": "string"
+                }
+            }
+        },
+        "database.CreateIndexRequest": {
+            "type": "object",
+            "properties": {
+                "columns": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "is_unique": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "database.CreateTableRequest": {
+            "type": "object"
+        },
+        "database.FunctionResponse": {
+            "type": "object",
+            "properties": {
+                "dataType": {
+                    "type": "string"
+                },
+                "definition": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "database.RenameColumnRequest": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "database.RenameTableRequest": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "database.TableResponse": {
+            "type": "object",
+            "properties": {
+                "estimatedRows": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "schema": {
+                    "type": "string"
+                },
+                "totalSize": {
+                    "type": "string"
+                }
+            }
+        },
+        "database.UploadTableRequest": {
+            "type": "object"
+        },
+        "database.functionParameter": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.DefaultRequestWithProjectHeader": {
+            "type": "object",
+            "properties": {
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "file.CreateRequest": {
+            "type": "object",
+            "properties": {
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "file.RenameRequest": {
+            "type": "object",
+            "properties": {
+                "full_file_name": {
+                    "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "file.Response": {
             "type": "object",
             "properties": {
                 "containerUuid": {
@@ -4610,7 +4820,100 @@
                 }
             }
         },
-        "resources.FormFieldResponse": {
+        "form.CreateFormFieldsRequest": {
+            "type": "object",
+            "properties": {
+                "fields": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/form.FieldRequest"
+                    }
+                },
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "form.CreateRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "form.CreateResponseRequest": {
+            "type": "object",
+            "properties": {
+                "projectUUID": {
+                    "type": "string"
+                },
+                "response": {
+                    "type": "object",
+                    "additionalProperties": true
+                }
+            }
+        },
+        "form.FieldRequest": {
+            "type": "object",
+            "properties": {
+                "date_format": {
+                    "description": "fails if provided and field value doesn't match",
+                    "type": "string"
+                },
+                "default_value": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "end_date": {
+                    "type": "string"
+                },
+                "is_required": {
+                    "type": "boolean"
+                },
+                "label": {
+                    "description": "required fields",
+                    "type": "string"
+                },
+                "max_length": {
+                    "type": "integer"
+                },
+                "max_value": {
+                    "type": "integer"
+                },
+                "min_length": {
+                    "description": "all fields from this point are optional",
+                    "type": "integer"
+                },
+                "min_value": {
+                    "description": "only applicable for number types",
+                    "type": "integer"
+                },
+                "options": {
+                    "description": "Options for select/radio types",
+                    "type": "string"
+                },
+                "pattern": {
+                    "type": "string"
+                },
+                "start_date": {
+                    "description": "only applicable for date types",
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "form.FieldResponseApi": {
             "type": "object",
             "properties": {
                 "createdAt": {
@@ -4669,7 +4972,7 @@
                 }
             }
         },
-        "resources.FormFieldResponseForAPI": {
+        "form.FieldResponseForAPI": {
             "type": "object",
             "properties": {
                 "createdAt": {
@@ -4692,7 +4995,7 @@
                 }
             }
         },
-        "resources.FormResponse": {
+        "form.Response": {
             "type": "object",
             "properties": {
                 "createdAt": {
@@ -4721,7 +5024,7 @@
                 }
             }
         },
-        "resources.FormResponseForAPI": {
+        "form.ResponseForAPI": {
             "type": "object",
             "properties": {
                 "formUuid": {
@@ -4730,7 +5033,7 @@
                 "responses": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/resources.FormFieldResponseForAPI"
+                        "$ref": "#/definitions/form.FieldResponseForAPI"
                     }
                 },
                 "uuid": {
@@ -4738,19 +5041,55 @@
                 }
             }
         },
-        "resources.FunctionResponse": {
+        "form.UpdateFormFieldRequest": {
             "type": "object",
             "properties": {
-                "dataType": {
+                "date_format": {
+                    "description": "fails if provided and field value doesn't match",
                     "type": "string"
                 },
-                "definition": {
+                "default_value": {
                     "type": "string"
                 },
-                "language": {
+                "description": {
                     "type": "string"
                 },
-                "name": {
+                "end_date": {
+                    "type": "string"
+                },
+                "is_required": {
+                    "type": "boolean"
+                },
+                "label": {
+                    "description": "required fields",
+                    "type": "string"
+                },
+                "max_length": {
+                    "type": "integer"
+                },
+                "max_value": {
+                    "type": "integer"
+                },
+                "min_length": {
+                    "description": "all fields from this point are optional",
+                    "type": "integer"
+                },
+                "min_value": {
+                    "description": "only applicable for number types",
+                    "type": "integer"
+                },
+                "options": {
+                    "description": "Options for select/radio types",
+                    "type": "string"
+                },
+                "pattern": {
+                    "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
+                },
+                "start_date": {
+                    "description": "only applicable for date types",
                     "type": "string"
                 },
                 "type": {
@@ -4758,7 +5097,64 @@
                 }
             }
         },
-        "resources.OrganizationResponse": {
+        "logging.Response": {
+            "type": "object",
+            "properties": {
+                "body": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "endpoint": {
+                    "type": "string"
+                },
+                "ipAddress": {
+                    "type": "string"
+                },
+                "method": {
+                    "type": "string"
+                },
+                "params": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "integer"
+                },
+                "userAgent": {
+                    "type": "string"
+                },
+                "userUuid": {
+                    "type": "string"
+                },
+                "uuid": {
+                    "type": "string"
+                }
+            }
+        },
+        "organization.CreateRequest": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "organization.MemberCreateRequest": {
+            "type": "object",
+            "properties": {
+                "projectUUID": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "organization.Response": {
             "type": "object",
             "properties": {
                 "createdAt": {
@@ -4781,7 +5177,24 @@
                 }
             }
         },
-        "resources.ProjectResponse": {
+        "project.CreateRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "organization_uuid": {
+                    "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "project.Response": {
             "type": "object",
             "properties": {
                 "createdAt": {
@@ -4816,27 +5229,70 @@
                 }
             }
         },
-        "resources.TableResponse": {
+        "project.UpdateRequest": {
             "type": "object",
             "properties": {
-                "estimatedRows": {
-                    "type": "integer"
-                },
-                "id": {
-                    "type": "integer"
+                "description": {
+                    "type": "string"
                 },
                 "name": {
                     "type": "string"
                 },
-                "schema": {
-                    "type": "string"
-                },
-                "totalSize": {
+                "projectUUID": {
                     "type": "string"
                 }
             }
         },
-        "resources.UserResponse": {
+        "response.Response": {
+            "type": "object",
+            "properties": {
+                "content": {},
+                "errors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "user.CreateRequest": {
+            "type": "object",
+            "properties": {
+                "bio": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "user.LoginRequest": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                },
+                "projectUUID": {
+                    "type": "string"
+                }
+            }
+        },
+        "user.Response": {
             "type": "object",
             "properties": {
                 "bio": {
@@ -4865,38 +5321,16 @@
                 }
             }
         },
-        "responses.Response": {
+        "user.UpdateRequest": {
             "type": "object",
             "properties": {
-                "content": {},
-                "errors": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                "bio": {
+                    "type": "string"
                 },
-                "success": {
-                    "type": "boolean"
+                "projectUUID": {
+                    "type": "string"
                 }
             }
-        },
-        "table_requests.CreateRequest": {
-            "type": "object"
-        },
-        "table_requests.RenameRequest": {
-            "type": "object"
-        },
-        "table_requests.UploadRequest": {
-            "type": "object"
-        },
-        "user_requests.CreateRequest": {
-            "type": "object"
-        },
-        "user_requests.LoginRequest": {
-            "type": "object"
-        },
-        "user_requests.UpdateRequest": {
-            "type": "object"
         }
     }
 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,38 +1,6 @@
 basePath: /v2
 definitions:
-  column_requests.CreateRequest:
-    type: object
-  column_requests.RenameRequest:
-    type: object
-  container_requests.CreateFileRequest:
-    type: object
-  container_requests.CreateRequest:
-    type: object
-  container_requests.RenameFileRequest:
-    type: object
-  form_requests.CreateFormFieldsRequest:
-    type: object
-  form_requests.CreateRequest:
-    type: object
-  form_requests.CreateResponseRequest:
-    type: object
-  form_requests.UpdateFormFieldRequest:
-    type: object
-  organization_requests.CreateRequest:
-    type: object
-  organization_requests.MemberCreateRequest:
-    type: object
-  project_requests.CreateRequest:
-    type: object
-  project_requests.UpdateRequest:
-    type: object
-  requests.CreateFunctionRequest:
-    type: object
-  requests.DefaultRequestWithProjectHeader:
-    type: object
-  requests.IndexCreateRequest:
-    type: object
-  resources.BackupResponse:
+  backup.Response:
     properties:
       completedAt:
         type: string
@@ -47,30 +15,20 @@ definitions:
       uuid:
         type: string
     type: object
-  resources.ColumnResponse:
+  container.CreateRequest:
     properties:
-      defaultValue:
+      description:
         type: string
-      foreign:
+      is_public:
         type: boolean
+      max_file_size:
+        type: integer
       name:
         type: string
-      notNull:
-        type: boolean
-      position:
-        type: integer
-      primary:
-        type: boolean
-      referenceColumn:
+      projectUUID:
         type: string
-      referenceTable:
-        type: string
-      type:
-        type: string
-      unique:
-        type: boolean
     type: object
-  resources.ContainerResponse:
+  container.Response:
     properties:
       createdAt:
         type: string
@@ -97,7 +55,130 @@ definitions:
       uuid:
         type: string
     type: object
-  resources.FileResponse:
+  database.ColumnResponse:
+    properties:
+      defaultValue:
+        type: string
+      foreign:
+        type: boolean
+      name:
+        type: string
+      notNull:
+        type: boolean
+      position:
+        type: integer
+      primary:
+        type: boolean
+      referenceColumn:
+        type: string
+      referenceTable:
+        type: string
+      type:
+        type: string
+      unique:
+        type: boolean
+    type: object
+  database.CreateColumnRequest:
+    type: object
+  database.CreateFunctionRequest:
+    properties:
+      definition:
+        type: string
+      language:
+        type: string
+      name:
+        type: string
+      parameters:
+        items:
+          $ref: '#/definitions/database.functionParameter'
+        type: array
+      projectUUID:
+        type: string
+      return_type:
+        type: string
+    type: object
+  database.CreateIndexRequest:
+    properties:
+      columns:
+        items:
+          type: string
+        type: array
+      is_unique:
+        type: boolean
+      name:
+        type: string
+      projectUUID:
+        type: string
+    type: object
+  database.CreateTableRequest:
+    type: object
+  database.FunctionResponse:
+    properties:
+      dataType:
+        type: string
+      definition:
+        type: string
+      language:
+        type: string
+      name:
+        type: string
+      type:
+        type: string
+    type: object
+  database.RenameColumnRequest:
+    properties:
+      name:
+        type: string
+      projectUUID:
+        type: string
+    type: object
+  database.RenameTableRequest:
+    properties:
+      name:
+        type: string
+      projectUUID:
+        type: string
+    type: object
+  database.TableResponse:
+    properties:
+      estimatedRows:
+        type: integer
+      id:
+        type: integer
+      name:
+        type: string
+      schema:
+        type: string
+      totalSize:
+        type: string
+    type: object
+  database.UploadTableRequest:
+    type: object
+  database.functionParameter:
+    properties:
+      name:
+        type: string
+      type:
+        type: string
+    type: object
+  dto.DefaultRequestWithProjectHeader:
+    properties:
+      projectUUID:
+        type: string
+    type: object
+  file.CreateRequest:
+    properties:
+      projectUUID:
+        type: string
+    type: object
+  file.RenameRequest:
+    properties:
+      full_file_name:
+        type: string
+      projectUUID:
+        type: string
+    type: object
+  file.Response:
     properties:
       containerUuid:
         type: string
@@ -119,7 +200,70 @@ definitions:
       uuid:
         type: string
     type: object
-  resources.FormFieldResponse:
+  form.CreateFormFieldsRequest:
+    properties:
+      fields:
+        items:
+          $ref: '#/definitions/form.FieldRequest'
+        type: array
+      projectUUID:
+        type: string
+    type: object
+  form.CreateRequest:
+    properties:
+      description:
+        type: string
+      name:
+        type: string
+      projectUUID:
+        type: string
+    type: object
+  form.CreateResponseRequest:
+    properties:
+      projectUUID:
+        type: string
+      response:
+        additionalProperties: true
+        type: object
+    type: object
+  form.FieldRequest:
+    properties:
+      date_format:
+        description: fails if provided and field value doesn't match
+        type: string
+      default_value:
+        type: string
+      description:
+        type: string
+      end_date:
+        type: string
+      is_required:
+        type: boolean
+      label:
+        description: required fields
+        type: string
+      max_length:
+        type: integer
+      max_value:
+        type: integer
+      min_length:
+        description: all fields from this point are optional
+        type: integer
+      min_value:
+        description: only applicable for number types
+        type: integer
+      options:
+        description: Options for select/radio types
+        type: string
+      pattern:
+        type: string
+      start_date:
+        description: only applicable for date types
+        type: string
+      type:
+        type: string
+    type: object
+  form.FieldResponseApi:
     properties:
       createdAt:
         type: string
@@ -158,7 +302,7 @@ definitions:
       uuid:
         type: string
     type: object
-  resources.FormFieldResponseForAPI:
+  form.FieldResponseForAPI:
     properties:
       createdAt:
         type: string
@@ -173,7 +317,7 @@ definitions:
       value:
         type: string
     type: object
-  resources.FormResponse:
+  form.Response:
     properties:
       createdAt:
         type: string
@@ -192,31 +336,94 @@ definitions:
       uuid:
         type: string
     type: object
-  resources.FormResponseForAPI:
+  form.ResponseForAPI:
     properties:
       formUuid:
         type: string
       responses:
         items:
-          $ref: '#/definitions/resources.FormFieldResponseForAPI'
+          $ref: '#/definitions/form.FieldResponseForAPI'
         type: array
       uuid:
         type: string
     type: object
-  resources.FunctionResponse:
+  form.UpdateFormFieldRequest:
     properties:
-      dataType:
+      date_format:
+        description: fails if provided and field value doesn't match
         type: string
-      definition:
+      default_value:
         type: string
-      language:
+      description:
         type: string
-      name:
+      end_date:
+        type: string
+      is_required:
+        type: boolean
+      label:
+        description: required fields
+        type: string
+      max_length:
+        type: integer
+      max_value:
+        type: integer
+      min_length:
+        description: all fields from this point are optional
+        type: integer
+      min_value:
+        description: only applicable for number types
+        type: integer
+      options:
+        description: Options for select/radio types
+        type: string
+      pattern:
+        type: string
+      projectUUID:
+        type: string
+      start_date:
+        description: only applicable for date types
         type: string
       type:
         type: string
     type: object
-  resources.OrganizationResponse:
+  logging.Response:
+    properties:
+      body:
+        type: string
+      createdAt:
+        type: string
+      endpoint:
+        type: string
+      ipAddress:
+        type: string
+      method:
+        type: string
+      params:
+        type: string
+      status:
+        type: integer
+      userAgent:
+        type: string
+      userUuid:
+        type: string
+      uuid:
+        type: string
+    type: object
+  organization.CreateRequest:
+    properties:
+      name:
+        type: string
+      projectUUID:
+        type: string
+    type: object
+  organization.MemberCreateRequest:
+    properties:
+      projectUUID:
+        type: string
+      user_id:
+        type: string
+    type: object
+  organization.Response:
     properties:
       createdAt:
         type: string
@@ -231,7 +438,18 @@ definitions:
       uuid:
         type: string
     type: object
-  resources.ProjectResponse:
+  project.CreateRequest:
+    properties:
+      description:
+        type: string
+      name:
+        type: string
+      organization_uuid:
+        type: string
+      projectUUID:
+        type: string
+    type: object
+  project.Response:
     properties:
       createdAt:
         type: string
@@ -254,20 +472,48 @@ definitions:
       uuid:
         type: string
     type: object
-  resources.TableResponse:
+  project.UpdateRequest:
     properties:
-      estimatedRows:
-        type: integer
-      id:
-        type: integer
+      description:
+        type: string
       name:
         type: string
-      schema:
-        type: string
-      totalSize:
+      projectUUID:
         type: string
     type: object
-  resources.UserResponse:
+  response.Response:
+    properties:
+      content: {}
+      errors:
+        items:
+          type: string
+        type: array
+      success:
+        type: boolean
+    type: object
+  user.CreateRequest:
+    properties:
+      bio:
+        type: string
+      email:
+        type: string
+      password:
+        type: string
+      projectUUID:
+        type: string
+      username:
+        type: string
+    type: object
+  user.LoginRequest:
+    properties:
+      email:
+        type: string
+      password:
+        type: string
+      projectUUID:
+        type: string
+    type: object
+  user.Response:
     properties:
       bio:
         type: string
@@ -286,27 +532,12 @@ definitions:
       uuid:
         type: string
     type: object
-  responses.Response:
+  user.UpdateRequest:
     properties:
-      content: {}
-      errors:
-        items:
-          type: string
-        type: array
-      success:
-        type: boolean
-    type: object
-  table_requests.CreateRequest:
-    type: object
-  table_requests.RenameRequest:
-    type: object
-  table_requests.UploadRequest:
-    type: object
-  user_requests.CreateRequest:
-    type: object
-  user_requests.LoginRequest:
-    type: object
-  user_requests.UpdateRequest:
+      bio:
+        type: string
+      projectUUID:
+        type: string
     type: object
 host: fluxton.io/api
 info:
@@ -319,6 +550,58 @@ info:
   title: Fluxton API
   version: "1.0"
 paths:
+  /admin/logs:
+    get:
+      consumes:
+      - application/json
+      description: Get all logs
+      parameters:
+      - description: Bearer Token
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Page number for pagination
+        in: query
+        name: page
+        type: string
+      - description: Number of items per page
+        in: query
+        name: limit
+        type: string
+      - description: Field to sort by
+        in: query
+        name: sort
+        type: string
+      - description: Sort order (asc or desc)
+        in: query
+        name: order
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of files
+          schema:
+            items:
+              allOf:
+              - $ref: '#/definitions/response.Response'
+              - properties:
+                  content:
+                    items:
+                      $ref: '#/definitions/logging.Response'
+                    type: array
+                type: object
+            type: array
+        "400":
+          description: Invalid input
+        "401":
+          description: Unauthorized
+        "500":
+          description: Internal server error
+      summary: List all logs
+      tags:
+      - Logs
   /backups:
     get:
       consumes:
@@ -343,11 +626,11 @@ paths:
           schema:
             items:
               allOf:
-              - $ref: '#/definitions/responses.Response'
+              - $ref: '#/definitions/response.Response'
               - properties:
                   content:
                     items:
-                      $ref: '#/definitions/resources.BackupResponse'
+                      $ref: '#/definitions/backup.Response'
                     type: array
                 type: object
             type: array
@@ -378,7 +661,7 @@ paths:
         name: backup
         required: true
         schema:
-          $ref: '#/definitions/requests.DefaultRequestWithProjectHeader'
+          $ref: '#/definitions/dto.DefaultRequestWithProjectHeader'
       produces:
       - application/json
       responses:
@@ -386,10 +669,10 @@ paths:
           description: Backup created
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.BackupResponse'
+                  $ref: '#/definitions/backup.Response'
               type: object
         "400":
           description: Invalid input
@@ -464,10 +747,10 @@ paths:
           description: Backup details
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.BackupResponse'
+                  $ref: '#/definitions/backup.Response'
               type: object
         "400":
           description: Invalid input
@@ -518,11 +801,11 @@ paths:
           schema:
             items:
               allOf:
-              - $ref: '#/definitions/responses.Response'
+              - $ref: '#/definitions/response.Response'
               - properties:
                   content:
                     items:
-                      $ref: '#/definitions/resources.FileResponse'
+                      $ref: '#/definitions/file.Response'
                     type: array
                 type: object
             type: array
@@ -555,7 +838,7 @@ paths:
         name: file
         required: true
         schema:
-          $ref: '#/definitions/container_requests.CreateFileRequest'
+          $ref: '#/definitions/file.CreateRequest'
       produces:
       - application/json
       responses:
@@ -563,10 +846,10 @@ paths:
           description: File details
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.FileResponse'
+                  $ref: '#/definitions/file.Response'
               type: object
         "400":
           description: Invalid input
@@ -639,10 +922,10 @@ paths:
           description: File details
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.FileResponse'
+                  $ref: '#/definitions/file.Response'
               type: object
         "400":
           description: Invalid input
@@ -680,7 +963,7 @@ paths:
         name: file
         required: true
         schema:
-          $ref: '#/definitions/container_requests.RenameFileRequest'
+          $ref: '#/definitions/file.RenameRequest'
       produces:
       - application/json
       responses:
@@ -688,10 +971,10 @@ paths:
           description: File details
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.FileResponse'
+                  $ref: '#/definitions/file.Response'
               type: object
         "400":
           description: Invalid input
@@ -742,11 +1025,11 @@ paths:
           schema:
             items:
               allOf:
-              - $ref: '#/definitions/responses.Response'
+              - $ref: '#/definitions/response.Response'
               - properties:
                   content:
                     items:
-                      $ref: '#/definitions/resources.FormResponse'
+                      $ref: '#/definitions/form.Response'
                     type: array
                 type: object
             type: array
@@ -779,7 +1062,7 @@ paths:
         name: form
         required: true
         schema:
-          $ref: '#/definitions/form_requests.CreateRequest'
+          $ref: '#/definitions/form.CreateRequest'
       produces:
       - application/json
       responses:
@@ -787,10 +1070,10 @@ paths:
           description: Form created
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.FormResponse'
+                  $ref: '#/definitions/form.Response'
               type: object
         "400":
           description: Invalid input
@@ -865,10 +1148,10 @@ paths:
           description: Form details
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.FormResponse'
+                  $ref: '#/definitions/form.Response'
               type: object
         "400":
           description: Invalid input
@@ -904,7 +1187,7 @@ paths:
         name: form
         required: true
         schema:
-          $ref: '#/definitions/form_requests.CreateRequest'
+          $ref: '#/definitions/form.CreateRequest'
       produces:
       - application/json
       responses:
@@ -912,10 +1195,10 @@ paths:
           description: Form updated
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.FormResponse'
+                  $ref: '#/definitions/form.Response'
               type: object
         "400":
           description: Invalid input
@@ -952,11 +1235,11 @@ paths:
           schema:
             items:
               allOf:
-              - $ref: '#/definitions/responses.Response'
+              - $ref: '#/definitions/response.Response'
               - properties:
                   content:
                     items:
-                      $ref: '#/definitions/resources.FormFieldResponse'
+                      $ref: '#/definitions/form.FieldResponseApi'
                     type: array
                 type: object
             type: array
@@ -984,7 +1267,7 @@ paths:
         name: field
         required: true
         schema:
-          $ref: '#/definitions/form_requests.CreateFormFieldsRequest'
+          $ref: '#/definitions/form.CreateFormFieldsRequest'
       - description: Form UUID
         in: path
         name: formUUID
@@ -997,10 +1280,10 @@ paths:
           description: Field created
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.FormFieldResponse'
+                  $ref: '#/definitions/form.FieldResponseApi'
               type: object
         "400":
           description: Invalid input
@@ -1075,10 +1358,10 @@ paths:
           description: Field details
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.FormFieldResponse'
+                  $ref: '#/definitions/form.FieldResponseApi'
               type: object
         "400":
           description: Invalid input
@@ -1104,7 +1387,7 @@ paths:
         name: field
         required: true
         schema:
-          $ref: '#/definitions/form_requests.UpdateFormFieldRequest'
+          $ref: '#/definitions/form.UpdateFormFieldRequest'
       - description: Form UUID
         in: path
         name: formUUID
@@ -1122,10 +1405,10 @@ paths:
           description: Field updated
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.FormFieldResponse'
+                  $ref: '#/definitions/form.FieldResponseApi'
               type: object
         "400":
           description: Invalid input
@@ -1166,11 +1449,11 @@ paths:
           description: List of form responses
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
                   items:
-                    $ref: '#/definitions/resources.FormResponseForAPI'
+                    $ref: '#/definitions/form.ResponseForAPI'
                   type: array
               type: object
         "400":
@@ -1207,7 +1490,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/form_requests.CreateResponseRequest'
+          $ref: '#/definitions/form.CreateResponseRequest'
       produces:
       - application/json
       responses:
@@ -1215,10 +1498,10 @@ paths:
           description: Form response details
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.FormResponseForAPI'
+                  $ref: '#/definitions/form.ResponseForAPI'
               type: object
         "400":
           description: Invalid input
@@ -1303,10 +1586,10 @@ paths:
           description: Form response details
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.FormResponseForAPI'
+                  $ref: '#/definitions/form.ResponseForAPI'
               type: object
         "400":
           description: Invalid input
@@ -1351,11 +1634,11 @@ paths:
           schema:
             items:
               allOf:
-              - $ref: '#/definitions/responses.Response'
+              - $ref: '#/definitions/response.Response'
               - properties:
                   content:
                     items:
-                      $ref: '#/definitions/resources.FunctionResponse'
+                      $ref: '#/definitions/database.FunctionResponse'
                     type: array
                 type: object
             type: array
@@ -1385,10 +1668,10 @@ paths:
         type: string
       - description: Function details
         in: body
-        name: form
+        name: function
         required: true
         schema:
-          $ref: '#/definitions/requests.CreateFunctionRequest'
+          $ref: '#/definitions/database.CreateFunctionRequest'
       produces:
       - application/json
       responses:
@@ -1396,10 +1679,10 @@ paths:
           description: Function created
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.FunctionResponse'
+                  $ref: '#/definitions/database.FunctionResponse'
               type: object
         "400":
           description: Invalid input
@@ -1489,10 +1772,10 @@ paths:
           description: Function details
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.FunctionResponse'
+                  $ref: '#/definitions/database.FunctionResponse'
               type: object
         "400":
           description: Invalid input
@@ -1537,11 +1820,11 @@ paths:
           description: List of organizations
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
                   items:
-                    $ref: '#/definitions/resources.OrganizationResponse'
+                    $ref: '#/definitions/organization.Response'
                   type: array
               type: object
         "401":
@@ -1566,7 +1849,7 @@ paths:
         name: organization
         required: true
         schema:
-          $ref: '#/definitions/organization_requests.CreateRequest'
+          $ref: '#/definitions/organization.CreateRequest'
       produces:
       - application/json
       responses:
@@ -1574,10 +1857,10 @@ paths:
           description: Organization created
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.OrganizationResponse'
+                  $ref: '#/definitions/organization.Response'
               type: object
         "400":
           description: Invalid input
@@ -1612,7 +1895,7 @@ paths:
         "204":
           description: Organization deleted
           schema:
-            $ref: '#/definitions/responses.Response'
+            $ref: '#/definitions/response.Response'
         "401":
           description: Unauthorized
         "500":
@@ -1642,10 +1925,10 @@ paths:
           description: Organization details
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.OrganizationResponse'
+                  $ref: '#/definitions/organization.Response'
               type: object
         "400":
           description: Invalid input
@@ -1678,7 +1961,7 @@ paths:
         name: organization
         required: true
         schema:
-          $ref: '#/definitions/organization_requests.CreateRequest'
+          $ref: '#/definitions/organization.CreateRequest'
       produces:
       - application/json
       responses:
@@ -1686,10 +1969,10 @@ paths:
           description: Organization updated
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.OrganizationResponse'
+                  $ref: '#/definitions/organization.Response'
               type: object
         "400":
           description: Invalid input
@@ -1725,11 +2008,11 @@ paths:
           description: User created
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
                   items:
-                    $ref: '#/definitions/resources.UserResponse'
+                    $ref: '#/definitions/user.Response'
                   type: array
               type: object
         "400":
@@ -1763,7 +2046,7 @@ paths:
         name: user
         required: true
         schema:
-          $ref: '#/definitions/organization_requests.MemberCreateRequest'
+          $ref: '#/definitions/organization.MemberCreateRequest'
       produces:
       - application/json
       responses:
@@ -1771,10 +2054,10 @@ paths:
           description: User created
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.UserResponse'
+                  $ref: '#/definitions/user.Response'
               type: object
         "400":
           description: Invalid input
@@ -1863,11 +2146,11 @@ paths:
           description: List of projects
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
                   items:
-                    $ref: '#/definitions/resources.ProjectResponse'
+                    $ref: '#/definitions/project.Response'
                   type: array
               type: object
         "400":
@@ -1899,7 +2182,7 @@ paths:
         name: name
         required: true
         schema:
-          $ref: '#/definitions/project_requests.CreateRequest'
+          $ref: '#/definitions/project.CreateRequest'
       produces:
       - application/json
       responses:
@@ -1907,10 +2190,10 @@ paths:
           description: Project details
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.ProjectResponse'
+                  $ref: '#/definitions/project.Response'
               type: object
         "400":
           description: Invalid input
@@ -1945,7 +2228,7 @@ paths:
         "200":
           description: Project deleted
           schema:
-            $ref: '#/definitions/responses.Response'
+            $ref: '#/definitions/response.Response'
         "400":
           description: Invalid input
         "401":
@@ -1977,10 +2260,10 @@ paths:
           description: Project details
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.ProjectResponse'
+                  $ref: '#/definitions/project.Response'
               type: object
         "400":
           description: Invalid input
@@ -2013,7 +2296,7 @@ paths:
         name: name
         required: true
         schema:
-          $ref: '#/definitions/project_requests.UpdateRequest'
+          $ref: '#/definitions/project.UpdateRequest'
       produces:
       - application/json
       responses:
@@ -2021,10 +2304,10 @@ paths:
           description: Project details
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.ProjectResponse'
+                  $ref: '#/definitions/project.Response'
               type: object
         "400":
           description: Invalid input
@@ -2076,11 +2359,11 @@ paths:
           description: List of container
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
                   items:
-                    $ref: '#/definitions/resources.ContainerResponse'
+                    $ref: '#/definitions/container.Response'
                   type: array
               type: object
         "400":
@@ -2112,7 +2395,7 @@ paths:
         name: container
         required: true
         schema:
-          $ref: '#/definitions/container_requests.CreateRequest'
+          $ref: '#/definitions/container.CreateRequest'
       produces:
       - application/json
       responses:
@@ -2120,10 +2403,10 @@ paths:
           description: Container created
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.ContainerResponse'
+                  $ref: '#/definitions/container.Response'
               type: object
         "400":
           description: Invalid input
@@ -2198,10 +2481,10 @@ paths:
           description: Container details
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.ContainerResponse'
+                  $ref: '#/definitions/container.Response'
               type: object
         "400":
           description: Invalid input
@@ -2239,7 +2522,7 @@ paths:
         name: container
         required: true
         schema:
-          $ref: '#/definitions/container_requests.CreateRequest'
+          $ref: '#/definitions/container.CreateRequest'
       produces:
       - application/json
       responses:
@@ -2247,10 +2530,10 @@ paths:
           description: Container updated
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.ContainerResponse'
+                  $ref: '#/definitions/container.Response'
               type: object
         "400":
           description: Invalid input
@@ -2286,11 +2569,11 @@ paths:
           description: List of tables
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
                   items:
-                    $ref: '#/definitions/resources.TableResponse'
+                    $ref: '#/definitions/database.TableResponse'
                   type: array
               type: object
         "400":
@@ -2322,7 +2605,7 @@ paths:
         name: table
         required: true
         schema:
-          $ref: '#/definitions/table_requests.CreateRequest'
+          $ref: '#/definitions/database.CreateTableRequest'
       produces:
       - application/json
       responses:
@@ -2330,10 +2613,10 @@ paths:
           description: Table created
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.TableResponse'
+                  $ref: '#/definitions/database.TableResponse'
               type: object
         "400":
           description: Invalid input
@@ -2369,11 +2652,11 @@ paths:
           description: List of columns
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
                   items:
-                    $ref: '#/definitions/resources.ColumnResponse'
+                    $ref: '#/definitions/database.ColumnResponse'
                   type: array
               type: object
         "400":
@@ -2410,7 +2693,7 @@ paths:
         name: columns
         required: true
         schema:
-          $ref: '#/definitions/column_requests.CreateRequest'
+          $ref: '#/definitions/database.CreateColumnRequest'
       produces:
       - application/json
       responses:
@@ -2418,10 +2701,10 @@ paths:
           description: Columns created
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.TableResponse'
+                  $ref: '#/definitions/database.ColumnResponse'
               type: object
         "400":
           description: Invalid input
@@ -2459,7 +2742,7 @@ paths:
         name: columns
         required: true
         schema:
-          $ref: '#/definitions/column_requests.CreateRequest'
+          $ref: '#/definitions/database.CreateColumnRequest'
       produces:
       - application/json
       responses:
@@ -2467,10 +2750,10 @@ paths:
           description: Columns altered
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.TableResponse'
+                  $ref: '#/definitions/database.ColumnResponse'
               type: object
         "400":
           description: Invalid input
@@ -2555,14 +2838,14 @@ paths:
         name: new_name
         required: true
         schema:
-          $ref: '#/definitions/column_requests.RenameRequest'
+          $ref: '#/definitions/database.RenameColumnRequest'
       produces:
       - application/json
       responses:
         "200":
           description: Column renamed
           schema:
-            $ref: '#/definitions/responses.Response'
+            $ref: '#/definitions/response.Response'
         "400":
           description: Invalid input
         "401":
@@ -2638,10 +2921,10 @@ paths:
           description: Table details
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.TableResponse'
+                  $ref: '#/definitions/database.TableResponse'
               type: object
         "400":
           description: Invalid input
@@ -2680,7 +2963,7 @@ paths:
         name: new_name
         required: true
         schema:
-          $ref: '#/definitions/table_requests.RenameRequest'
+          $ref: '#/definitions/database.RenameTableRequest'
       produces:
       - application/json
       responses:
@@ -2688,10 +2971,10 @@ paths:
           description: Table duplicated
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.TableResponse'
+                  $ref: '#/definitions/database.TableResponse'
               type: object
         "400":
           description: Invalid input
@@ -2727,7 +3010,7 @@ paths:
           description: List of indexes
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
                   items: {}
@@ -2762,7 +3045,7 @@ paths:
         name: index
         required: true
         schema:
-          $ref: '#/definitions/requests.IndexCreateRequest'
+          $ref: '#/definitions/database.CreateIndexRequest'
       produces:
       - application/json
       responses:
@@ -2770,7 +3053,7 @@ paths:
           description: Index created
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content: {}
               type: object
@@ -2849,7 +3132,7 @@ paths:
           description: Index details
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content: {}
               type: object
@@ -2890,7 +3173,7 @@ paths:
         name: new_name
         required: true
         schema:
-          $ref: '#/definitions/table_requests.RenameRequest'
+          $ref: '#/definitions/database.RenameTableRequest'
       produces:
       - application/json
       responses:
@@ -2898,10 +3181,10 @@ paths:
           description: Table renamed
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.TableResponse'
+                  $ref: '#/definitions/database.TableResponse'
               type: object
         "400":
           description: Invalid input
@@ -2935,7 +3218,7 @@ paths:
         name: table
         required: true
         schema:
-          $ref: '#/definitions/table_requests.UploadRequest'
+          $ref: '#/definitions/database.UploadTableRequest'
       produces:
       - application/json
       responses:
@@ -2943,10 +3226,10 @@ paths:
           description: Table created
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.TableResponse'
+                  $ref: '#/definitions/database.TableResponse'
               type: object
         "400":
           description: Invalid input
@@ -2970,7 +3253,7 @@ paths:
         name: user
         required: true
         schema:
-          $ref: '#/definitions/user_requests.CreateRequest'
+          $ref: '#/definitions/user.CreateRequest'
       produces:
       - application/json
       responses:
@@ -2978,10 +3261,10 @@ paths:
           description: User created
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.UserResponse'
+                  $ref: '#/definitions/user.Response'
               type: object
         "400":
           description: Invalid input
@@ -3015,10 +3298,10 @@ paths:
           description: User details
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.UserResponse'
+                  $ref: '#/definitions/user.Response'
               type: object
         "400":
           description: Invalid input
@@ -3049,7 +3332,7 @@ paths:
         name: user
         required: true
         schema:
-          $ref: '#/definitions/user_requests.UpdateRequest'
+          $ref: '#/definitions/user.UpdateRequest'
       produces:
       - application/json
       responses:
@@ -3057,10 +3340,10 @@ paths:
           description: User updated
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.UserResponse'
+                  $ref: '#/definitions/user.Response'
               type: object
         "400":
           description: Invalid input
@@ -3084,7 +3367,7 @@ paths:
         name: user
         required: true
         schema:
-          $ref: '#/definitions/user_requests.LoginRequest'
+          $ref: '#/definitions/user.LoginRequest'
       produces:
       - application/json
       responses:
@@ -3092,10 +3375,10 @@ paths:
           description: User details
           schema:
             allOf:
-            - $ref: '#/definitions/responses.Response'
+            - $ref: '#/definitions/response.Response'
             - properties:
                 content:
-                  $ref: '#/definitions/resources.UserResponse'
+                  $ref: '#/definitions/user.Response'
               type: object
         "400":
           description: Invalid input
@@ -3123,7 +3406,7 @@ paths:
         "200":
           description: User logged out
           schema:
-            $ref: '#/definitions/responses.Response'
+            $ref: '#/definitions/response.Response'
         "400":
           description: Invalid input
         "401":

--- a/internal/api/dto/base_project_request.go
+++ b/internal/api/dto/base_project_request.go
@@ -18,7 +18,5 @@ func (r *DefaultRequestWithProjectHeader) BindAndValidate(c echo.Context) []stri
 		return []string{err.Error()}
 	}
 
-	r.SetContext(c)
-
 	return nil
 }

--- a/internal/api/dto/base_request.go
+++ b/internal/api/dto/base_request.go
@@ -50,11 +50,6 @@ var (
 
 type BaseRequest struct {
 	ProjectUUID uuid.UUID `json:"projectUUID,omitempty"`
-	Context     echo.Context
-}
-
-func (r *BaseRequest) SetContext(c echo.Context) {
-	r.Context = c
 }
 
 func (r *BaseRequest) WithProjectHeader(c echo.Context) error {

--- a/internal/api/dto/database/column_requests.go
+++ b/internal/api/dto/database/column_requests.go
@@ -33,8 +33,6 @@ func (r *CreateColumnRequest) BindAndValidate(c echo.Context) []string {
 		return []string{err.Error()}
 	}
 
-	r.SetContext(c)
-
 	var requestErrors []string
 
 	for _, currentColumn := range r.Columns {
@@ -57,8 +55,6 @@ func (r *RenameColumnRequest) BindAndValidate(c echo.Context) []string {
 	if err != nil {
 		return []string{err.Error()}
 	}
-
-	r.SetContext(c)
 
 	err = validation.ValidateStruct(r,
 		validation.Field(

--- a/internal/api/dto/database/function_requests.go
+++ b/internal/api/dto/database/function_requests.go
@@ -35,8 +35,6 @@ func (r *CreateFunctionRequest) BindAndValidate(c echo.Context) []string {
 		return []string{err.Error()}
 	}
 
-	r.SetContext(c)
-
 	var errors []string
 
 	if err := r.validate(); err != nil {

--- a/internal/api/dto/database/index_requests.go
+++ b/internal/api/dto/database/index_requests.go
@@ -28,8 +28,6 @@ func (r *CreateIndexRequest) BindAndValidate(c echo.Context) []string {
 		return []string{err.Error()}
 	}
 
-	r.SetContext(c)
-
 	var errors []string
 
 	err = validation.ValidateStruct(r,

--- a/internal/api/dto/database/table_requests.go
+++ b/internal/api/dto/database/table_requests.go
@@ -44,8 +44,6 @@ func (r *UploadTableRequest) BindAndValidate(c echo.Context) []string {
 		return []string{err.Error()}
 	}
 
-	r.SetContext(c)
-
 	var errors []string
 	if err := r.validate(); err != nil {
 		errors = append(errors, r.ExtractValidationErrors(err)...)
@@ -91,8 +89,6 @@ func (r *RenameTableRequest) BindAndValidate(c echo.Context) []string {
 		return []string{err.Error()}
 	}
 
-	r.SetContext(c)
-
 	err = validation.ValidateStruct(r,
 		validation.Field(
 			&r.Name, validation.Required.Error("Name is required"),
@@ -124,8 +120,6 @@ func (r *CreateTableRequest) BindAndValidate(c echo.Context) []string {
 	if err != nil {
 		return []string{err.Error()}
 	}
-
-	r.SetContext(c)
 
 	var errors []string
 

--- a/internal/api/dto/default_request.go
+++ b/internal/api/dto/default_request.go
@@ -13,7 +13,5 @@ func (r *DefaultRequest) BindAndValidate(c echo.Context) []string {
 		return []string{"Invalid request payload"}
 	}
 
-	r.SetContext(c)
-
 	return nil
 }

--- a/internal/api/dto/form/requests.go
+++ b/internal/api/dto/form/requests.go
@@ -78,8 +78,6 @@ func (r *CreateRequest) BindAndValidate(c echo.Context) []string {
 		return []string{err.Error()}
 	}
 
-	r.SetContext(c)
-
 	err = validation.ValidateStruct(r,
 		validation.Field(
 			&r.Name,
@@ -111,8 +109,6 @@ func (r *CreateFormFieldsRequest) BindAndValidate(c echo.Context) []string {
 	if err != nil {
 		return []string{err.Error()}
 	}
-
-	r.SetContext(c)
 
 	err = validation.ValidateStruct(r,
 		validation.Field(&r.Fields, validation.Required.Error("Fields array is required"), validation.Each(
@@ -171,8 +167,6 @@ func (r *CreateResponseRequest) BindAndValidate(c echo.Context) []string {
 		return []string{err.Error()}
 	}
 
-	r.SetContext(c)
-
 	return nil
 }
 
@@ -185,8 +179,6 @@ func (r *UpdateFormFieldRequest) BindAndValidate(c echo.Context) []string {
 	if err != nil {
 		return []string{err.Error()}
 	}
-
-	r.SetContext(c)
 
 	return r.ExtractValidationErrors(validateField(r.FieldRequest))
 }

--- a/internal/api/dto/form/responses.go
+++ b/internal/api/dto/form/responses.go
@@ -16,7 +16,7 @@ type Response struct {
 	UpdatedAt   string    `json:"updatedAt"`
 }
 
-type FieldResponse struct {
+type FieldResponseApi struct {
 	Uuid         uuid.UUID   `json:"uuid"`
 	FormUuid     uuid.UUID   `json:"formUuid"`
 	Label        string      `json:"label"`

--- a/internal/api/dto/logging/requests.go
+++ b/internal/api/dto/logging/requests.go
@@ -1,0 +1,28 @@
+package logging
+
+import (
+	"fluxton/internal/api/dto"
+	"github.com/labstack/echo/v4"
+)
+
+type ListRequest struct {
+	dto.BaseRequest
+	UserUuid  string `query:"userUuid"`
+	Status    string `query:"status"`
+	Method    string `query:"method"`
+	Endpoint  string `query:"endpoint"`
+	IPAddress string `query:"ipAddress"`
+
+	Limit int    `query:"limit"`
+	Page  int    `query:"page"`
+	Sort  string `query:"sort"`
+	Order string `query:"order"`
+}
+
+func (r *ListRequest) BindAndValidate(c echo.Context) []string {
+	if err := c.Bind(r); err != nil {
+		return []string{"Invalid request payload"}
+	}
+
+	return nil
+}

--- a/internal/api/dto/logging/responses.go
+++ b/internal/api/dto/logging/responses.go
@@ -1,0 +1,18 @@
+package logging
+
+import (
+	"github.com/google/uuid"
+)
+
+type Response struct {
+	Uuid      uuid.UUID `json:"uuid"`
+	UserUuid  uuid.UUID `json:"userUuid"`
+	Method    string    `json:"method"`
+	Status    int       `json:"status"`
+	Endpoint  string    `json:"endpoint"`
+	IPAddress string    `json:"ipAddress"`
+	UserAgent string    `json:"userAgent"`
+	Params    string    `json:"params"`
+	Body      string    `json:"body"`
+	CreatedAt string    `json:"createdAt"`
+}

--- a/internal/api/dto/organization/requests.go
+++ b/internal/api/dto/organization/requests.go
@@ -21,8 +21,6 @@ func (r *CreateRequest) BindAndValidate(c echo.Context) []string {
 		return []string{"Invalid request payload"}
 	}
 
-	r.SetContext(c)
-
 	err := validation.ValidateStruct(r,
 		validation.Field(
 			&r.Name,
@@ -58,8 +56,6 @@ func (r *MemberCreateRequest) BindAndValidate(c echo.Context) []string {
 	err := validation.ValidateStruct(r,
 		validation.Field(&r.UserID, validation.Required.Error("UserID is required")),
 	)
-
-	r.SetContext(c)
 
 	return r.ExtractValidationErrors(err)
 }

--- a/internal/api/dto/project/requests.go
+++ b/internal/api/dto/project/requests.go
@@ -29,8 +29,6 @@ func (r *CreateRequest) BindAndValidate(c echo.Context) []string {
 		return []string{"Invalid request payload"}
 	}
 
-	r.SetContext(c)
-
 	err := validation.ValidateStruct(r,
 		validation.Field(
 			&r.Name,
@@ -57,8 +55,6 @@ func (r *UpdateRequest) BindAndValidate(c echo.Context) []string {
 	if err := c.Bind(r); err != nil {
 		return []string{"Invalid request payload"}
 	}
-
-	r.SetContext(c)
 
 	err := validation.ValidateStruct(r,
 		validation.Field(

--- a/internal/api/dto/setting/requests.go
+++ b/internal/api/dto/setting/requests.go
@@ -23,8 +23,6 @@ func (r *UpdateRequest) BindAndValidate(c echo.Context) []string {
 		return []string{"Invalid request payload"}
 	}
 
-	r.SetContext(c)
-
 	// Check if Settings slice is present
 	if len(r.Settings) == 0 {
 		return []string{"Settings required"}

--- a/internal/api/dto/storage/container/requests.go
+++ b/internal/api/dto/storage/container/requests.go
@@ -28,8 +28,6 @@ func (r *CreateRequest) BindAndValidate(c echo.Context) []string {
 		return []string{err.Error()}
 	}
 
-	r.SetContext(c)
-
 	err = validation.ValidateStruct(r,
 		validation.Field(
 			&r.Name,

--- a/internal/api/dto/storage/file/requests.go
+++ b/internal/api/dto/storage/file/requests.go
@@ -30,8 +30,6 @@ func (r *CreateRequest) BindAndValidate(c echo.Context) []string {
 		return []string{err.Error()}
 	}
 
-	r.SetContext(c)
-
 	err = validation.ValidateStruct(r,
 		validation.Field(
 			&r.FullFileName,
@@ -63,8 +61,6 @@ func (r *RenameRequest) BindAndValidate(c echo.Context) []string {
 	if err != nil {
 		return []string{err.Error()}
 	}
-
-	r.SetContext(c)
 
 	err = validation.ValidateStruct(r,
 		validation.Field(

--- a/internal/api/handlers/backup.go
+++ b/internal/api/handlers/backup.go
@@ -37,14 +37,14 @@ func NewBackupHandler(injector *do.Injector) (*BackupHandler, error) {
 // @Failure 500 "Internal server error"
 //
 // @Router /backups [get]
-func (bc *BackupHandler) List(c echo.Context) error {
+func (bh *BackupHandler) List(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
 	authUser, _ := auth.NewAuth(c).User()
 
-	backups, err := bc.backupService.List(request.ProjectUUID, authUser)
+	backups, err := bh.backupService.List(request.ProjectUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -72,7 +72,7 @@ func (bc *BackupHandler) List(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /backups/{backupUUID} [get]
-func (bc *BackupHandler) Show(c echo.Context) error {
+func (bh *BackupHandler) Show(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -85,7 +85,7 @@ func (bc *BackupHandler) Show(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	backup, err := bc.backupService.GetByUUID(backupUUID, authUser)
+	backup, err := bh.backupService.GetByUUID(backupUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -114,7 +114,7 @@ func (bc *BackupHandler) Show(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /backups [post]
-func (bc *BackupHandler) Store(c echo.Context) error {
+func (bh *BackupHandler) Store(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -122,7 +122,7 @@ func (bc *BackupHandler) Store(c echo.Context) error {
 
 	authUser, _ := auth.NewAuth(c).User()
 
-	backup, err := bc.backupService.Create(request.ProjectUUID, authUser)
+	backup, err := bh.backupService.Create(request.ProjectUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -150,7 +150,7 @@ func (bc *BackupHandler) Store(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /backups/{backupUUID} [delete]
-func (bc *BackupHandler) Delete(c echo.Context) error {
+func (bh *BackupHandler) Delete(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -163,7 +163,7 @@ func (bc *BackupHandler) Delete(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	if _, err := bc.backupService.Delete(backupUUID, authUser); err != nil {
+	if _, err := bh.backupService.Delete(backupUUID, authUser); err != nil {
 		return response.ErrorResponse(c, err)
 	}
 

--- a/internal/api/handlers/backup.go
+++ b/internal/api/handlers/backup.go
@@ -32,7 +32,7 @@ func NewBackupHandler(injector *do.Injector) (*BackupHandler, error) {
 // @Param Authorization header string true "Bearer Token"
 // @Param X-Project header string true "Project UUID"
 //
-// @Success 200 {array} responses.Response{content=[]backupDto.Response} "List of backups"
+// @Success 200 {array} response.Response{content=[]backup.Response} "List of backups"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
 //
@@ -66,7 +66,7 @@ func (bh *BackupHandler) List(c echo.Context) error {
 //
 // @Param backupUUID path string true "Backup UUID"
 //
-// @Success 200 {object} responses.Response{content=backupDto.Response} "Backup details"
+// @Success 200 {object} response.Response{content=backup.Response} "Backup details"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -105,9 +105,9 @@ func (bh *BackupHandler) Show(c echo.Context) error {
 // @Param Authorization header string true "Bearer Token"
 // @Param X-Project header string true "Project UUID"
 //
-// @Param backup body requests.DefaultRequestWithProjectHeader true "Project UUID"
+// @Param backup body dto.DefaultRequestWithProjectHeader true "Project UUID"
 //
-// @Success 201 {object} responses.Response{content=backupDto.Response} "Backup created"
+// @Success 201 {object} response.Response{content=backup.Response} "Backup created"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"

--- a/internal/api/handlers/column.go
+++ b/internal/api/handlers/column.go
@@ -34,7 +34,7 @@ func NewColumnHandler(injector *do.Injector) (*ColumnHandler, error) {
 // @Param Authorization header string true "Bearer Token"
 // @param Header X-Project header string true "Project UUID"
 //
-// @Success 200 {object} responses.Response{content=[]resources.ColumnResponse} "List of columns"
+// @Success 200 {object} response.Response{content=[]database.ColumnResponse} "List of columns"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -74,9 +74,9 @@ func (ch *ColumnHandler) List(c echo.Context) error {
 // @Param X-Project header string true "Project UUID"
 //
 // @Param fullTableName path string true "Full table name"
-// @Param columns body column_requests.CreateRequest true "Columns JSON"
+// @Param columns body database.CreateColumnRequest true "Columns JSON"
 //
-// @Success 201 {object} responses.Response{content=resources.TableResponse} "Columns created"
+// @Success 201 {object} response.Response{content=database.ColumnResponse} "Columns created"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 422 "Unprocessable entity"
@@ -117,9 +117,9 @@ func (ch *ColumnHandler) Store(c echo.Context) error {
 // @Param X-Project header string true "Project UUID"
 //
 // @Param fullTableName path string true "Full table name"
-// @Param columns body column_requests.CreateRequest true "Updated column definitions"
+// @Param columns body database.CreateColumnRequest true "Updated column definitions"
 //
-// @Success 200 {object} responses.Response{content=resources.TableResponse} "Columns altered"
+// @Success 200 {object} response.Response{content=database.ColumnResponse} "Columns altered"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 422 "Unprocessable entity"
@@ -161,9 +161,9 @@ func (ch *ColumnHandler) Alter(c echo.Context) error {
 //
 // @Param fullTableName path string true "Full table name"
 // @Param column_name path string true "Existing Column Name"
-// @Param new_name body column_requests.RenameRequest true "New column name JSON"
+// @Param new_name body database.RenameColumnRequest true "New column name JSON"
 //
-// @Success 200 {object} responses.Response "Column renamed"
+// @Success 200 {object} response.Response "Column renamed"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 422 "Unprocessable entity"

--- a/internal/api/handlers/column.go
+++ b/internal/api/handlers/column.go
@@ -40,7 +40,7 @@ func NewColumnHandler(injector *do.Injector) (*ColumnHandler, error) {
 // @Failure 500 "Internal server error"
 //
 // @Router /tables/{fullTableName}/columns [get]
-func (cc *ColumnHandler) List(c echo.Context) error {
+func (ch *ColumnHandler) List(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -53,7 +53,7 @@ func (cc *ColumnHandler) List(c echo.Context) error {
 		return response.BadRequestResponse(c, "Table name is required")
 	}
 
-	columns, err := cc.columnService.List(fullTableName, request.ProjectUUID, authUser)
+	columns, err := ch.columnService.List(fullTableName, request.ProjectUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -83,7 +83,7 @@ func (cc *ColumnHandler) List(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /tables/{fullTableName}/columns [post]
-func (cc *ColumnHandler) Store(c echo.Context) error {
+func (ch *ColumnHandler) Store(c echo.Context) error {
 	var request database.CreateColumnRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -96,7 +96,7 @@ func (cc *ColumnHandler) Store(c echo.Context) error {
 		return response.BadRequestResponse(c, "Table name is required")
 	}
 
-	columns, err := cc.columnService.CreateMany(fullTableName, database.ToCreateColumnInput(request), authUser)
+	columns, err := ch.columnService.CreateMany(fullTableName, database.ToCreateColumnInput(request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -126,7 +126,7 @@ func (cc *ColumnHandler) Store(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /tables/{fullTableName}/columns [put]
-func (cc *ColumnHandler) Alter(c echo.Context) error {
+func (ch *ColumnHandler) Alter(c echo.Context) error {
 	var request database.CreateColumnRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -139,7 +139,7 @@ func (cc *ColumnHandler) Alter(c echo.Context) error {
 		return response.BadRequestResponse(c, "Table name is required")
 	}
 
-	columns, err := cc.columnService.AlterMany(fullTableName, database.ToCreateColumnInput(request), authUser)
+	columns, err := ch.columnService.AlterMany(fullTableName, database.ToCreateColumnInput(request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -170,7 +170,7 @@ func (cc *ColumnHandler) Alter(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /tables/{fullTableName}/columns/{columnName} [put]
-func (cc *ColumnHandler) Rename(c echo.Context) error {
+func (ch *ColumnHandler) Rename(c echo.Context) error {
 	var request database.RenameColumnRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -178,12 +178,12 @@ func (cc *ColumnHandler) Rename(c echo.Context) error {
 
 	authUser, _ := auth.NewAuth(c).User()
 
-	fullTableName, columnName, err := cc.parseRequest(c)
+	fullTableName, columnName, err := ch.parseRequest(c)
 	if err != nil {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	columns, err := cc.columnService.Rename(columnName, fullTableName, database.ToRenameColumnInput(request), authUser)
+	columns, err := ch.columnService.Rename(columnName, fullTableName, database.ToRenameColumnInput(request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -213,7 +213,7 @@ func (cc *ColumnHandler) Rename(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /tables/{fullTableName}/columns/{columnName} [delete]
-func (cc *ColumnHandler) Delete(c echo.Context) error {
+func (ch *ColumnHandler) Delete(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -221,19 +221,19 @@ func (cc *ColumnHandler) Delete(c echo.Context) error {
 
 	authUser, _ := auth.NewAuth(c).User()
 
-	fullTableName, columnName, err := cc.parseRequest(c)
+	fullTableName, columnName, err := ch.parseRequest(c)
 	if err != nil {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	if _, err := cc.columnService.Delete(columnName, fullTableName, request.ProjectUUID, authUser); err != nil {
+	if _, err := ch.columnService.Delete(columnName, fullTableName, request.ProjectUUID, authUser); err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
 	return response.DeletedResponse(c, nil)
 }
 
-func (cc *ColumnHandler) parseRequest(c echo.Context) (string, string, error) {
+func (ch *ColumnHandler) parseRequest(c echo.Context) (string, string, error) {
 	fullTableName := c.Param("fullTableName")
 	if fullTableName == "" {
 		return "", "", errors.NewBadRequestError("Table name is required")

--- a/internal/api/handlers/container.go
+++ b/internal/api/handlers/container.go
@@ -38,7 +38,7 @@ func NewContainerHandler(injector *do.Injector) (*ContainerHandler, error) {
 // @Param sort query string false "Field to sort by"
 // @Param order query string false "Sort order (asc or desc)"
 //
-// @Success 200 {object} responses.Response{content=[]resources.ContainerResponse} "List of container"
+// @Success 200 {object} response.Response{content=[]container.Response} "List of container"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -75,7 +75,7 @@ func (ch *ContainerHandler) List(c echo.Context) error {
 //
 // @Param containerUUID path string true "Container UUID"
 //
-// @Success 200 {object} responses.Response{content=resources.ContainerResponse} "Container details"
+// @Success 200 {object} response.Response{content=container.Response} "Container details"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
@@ -111,9 +111,9 @@ func (ch *ContainerHandler) Show(c echo.Context) error {
 //
 // @Param Authorization header string true "Bearer Token"
 // @Param X-Project header string true "Project UUID"
-// @Param container body container_requests.CreateRequest true "Container details"
+// @Param container body container.CreateRequest true "Container details"
 //
-// @Success 201 {object} responses.Response{content=resources.ContainerResponse} "Container created"
+// @Success 201 {object} response.Response{content=container.Response} "Container created"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
@@ -149,9 +149,9 @@ func (ch *ContainerHandler) Store(c echo.Context) error {
 // @Param X-Project header string true "Project UUID"
 //
 // @Param containerUUID path string true "Container UUID"
-// @Param container body container_requests.CreateRequest true "Container details"
+// @Param container body container.CreateRequest true "Container details"
 //
-// @Success 200 {object} responses.Response{content=resources.ContainerResponse} "Container updated"
+// @Success 200 {object} response.Response{content=container.Response} "Container updated"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"

--- a/internal/api/handlers/file.go
+++ b/internal/api/handlers/file.go
@@ -44,7 +44,7 @@ func NewFileHandler(injector *do.Injector) (*FileHandler, error) {
 // @Failure 500 "Internal server error"
 //
 // @Router /containers/{containerUUID}/files [get]
-func (fc *FileHandler) List(c echo.Context) error {
+func (fh *FileHandler) List(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -58,7 +58,7 @@ func (fc *FileHandler) List(c echo.Context) error {
 	}
 
 	paginationParams := request.ExtractPaginationParams(c)
-	files, err := fc.fileService.List(paginationParams, containerUUID, authUser)
+	files, err := fh.fileService.List(paginationParams, containerUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -85,7 +85,7 @@ func (fc *FileHandler) List(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /containers/{containerUUID}/files/{fileUUID} [get]
-func (fc *FileHandler) Show(c echo.Context) error {
+func (fh *FileHandler) Show(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -103,7 +103,7 @@ func (fc *FileHandler) Show(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	fetchedFile, err := fc.fileService.GetByUUID(fileUUID, containerUUID, authUser)
+	fetchedFile, err := fh.fileService.GetByUUID(fileUUID, containerUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -130,7 +130,7 @@ func (fc *FileHandler) Show(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /containers/{containerUUID}/files [post]
-func (fc *FileHandler) Store(c echo.Context) error {
+func (fh *FileHandler) Store(c echo.Context) error {
 	var request file.CreateRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -143,7 +143,7 @@ func (fc *FileHandler) Store(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	createdFile, err := fc.fileService.Create(containerUUID, file.ToCreateFileInput(&request), authUser)
+	createdFile, err := fh.fileService.Create(containerUUID, file.ToCreateFileInput(&request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -171,7 +171,7 @@ func (fc *FileHandler) Store(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /containers/{containerUUID}/files/{fileUUID}/rename [put]
-func (fc *FileHandler) Rename(c echo.Context) error {
+func (fh *FileHandler) Rename(c echo.Context) error {
 	var request file.RenameRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -189,7 +189,7 @@ func (fc *FileHandler) Rename(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	updatedFile, err := fc.fileService.Rename(fileUUID, containerUUID, authUser, file.ToRenameFileInput(&request))
+	updatedFile, err := fh.fileService.Rename(fileUUID, containerUUID, authUser, file.ToRenameFileInput(&request))
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -216,7 +216,7 @@ func (fc *FileHandler) Rename(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /containers/{containerUUID}/files/{fileUUID} [delete]
-func (fc *FileHandler) Delete(c echo.Context) error {
+func (fh *FileHandler) Delete(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -234,7 +234,7 @@ func (fc *FileHandler) Delete(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	if _, err := fc.fileService.Delete(fileUUID, containerUUID, authUser); err != nil {
+	if _, err := fh.fileService.Delete(fileUUID, containerUUID, authUser); err != nil {
 		return response.ErrorResponse(c, err)
 	}
 

--- a/internal/api/handlers/file.go
+++ b/internal/api/handlers/file.go
@@ -38,7 +38,7 @@ func NewFileHandler(injector *do.Injector) (*FileHandler, error) {
 // @Param sort query string false "Field to sort by"
 // @Param order query string false "Sort order (asc or desc)"
 //
-// @Success 200 {array} responses.Response{content=[]resources.FileResponse} "List of files"
+// @Success 200 {array} response.Response{content=[]file.Response} "List of files"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -79,7 +79,7 @@ func (fh *FileHandler) List(c echo.Context) error {
 // @Param containerUUID path string true "Container UUID"
 // @Param fileUUID path string true "File UUID"
 //
-// @Success 200 {object} responses.Response{content=resources.FileResponse} "File details"
+// @Success 200 {object} response.Response{content=file.Response} "File details"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -122,9 +122,9 @@ func (fh *FileHandler) Show(c echo.Context) error {
 //
 // @Param Authorization header string true "Bearer Token"
 // @Param containerUUID path string true "Container UUID"
-// @Param file body container_requests.CreateRequest true "File details"
+// @Param file body file.CreateRequest true "File details"
 //
-// @Success 201 {object} responses.Response{content=resources.FileResponse} "File details"
+// @Success 201 {object} response.Response{content=file.Response} "File details"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -163,9 +163,9 @@ func (fh *FileHandler) Store(c echo.Context) error {
 // @Param Authorization header string true "Bearer Token"
 // @Param containerUUID path string true "Container UUID"
 // @Param fileUUID path string true "File UUID"
-// @Param file body container_requests.RenameRequest true "New file name"
+// @Param file body file.RenameRequest true "New file name"
 //
-// @Success 200 {object} responses.Response{content=resources.FileResponse} "File details"
+// @Success 200 {object} response.Response{content=file.Response} "File details"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"

--- a/internal/api/handlers/form.go
+++ b/internal/api/handlers/form.go
@@ -44,7 +44,7 @@ func NewFormHandler(injector *do.Injector) (*FormHandler, error) {
 // @Failure 500 "Internal server error"
 //
 // @Router /forms [get]
-func (fc *FormHandler) List(c echo.Context) error {
+func (fh *FormHandler) List(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -52,7 +52,7 @@ func (fc *FormHandler) List(c echo.Context) error {
 	authUser, _ := auth.NewAuth(c).User()
 
 	paginationParams := request.ExtractPaginationParams(c)
-	forms, err := fc.formService.List(paginationParams, request.ProjectUUID, authUser)
+	forms, err := fh.formService.List(paginationParams, request.ProjectUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -80,7 +80,7 @@ func (fc *FormHandler) List(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /forms/{formUUID} [get]
-func (fc *FormHandler) Show(c echo.Context) error {
+func (fh *FormHandler) Show(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -93,7 +93,7 @@ func (fc *FormHandler) Show(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	fetchedForm, err := fc.formService.GetByUUID(formUUID, authUser)
+	fetchedForm, err := fh.formService.GetByUUID(formUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -122,7 +122,7 @@ func (fc *FormHandler) Show(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /forms [post]
-func (fc *FormHandler) Store(c echo.Context) error {
+func (fh *FormHandler) Store(c echo.Context) error {
 	var request form.CreateRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -130,7 +130,7 @@ func (fc *FormHandler) Store(c echo.Context) error {
 
 	authUser, _ := auth.NewAuth(c).User()
 
-	createdForm, err := fc.formService.Create(form.ToCreateFormInput(&request), authUser)
+	createdForm, err := fh.formService.Create(form.ToCreateFormInput(&request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -160,7 +160,7 @@ func (fc *FormHandler) Store(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /forms/{formUUID} [put]
-func (fc *FormHandler) Update(c echo.Context) error {
+func (fh *FormHandler) Update(c echo.Context) error {
 	var request form.CreateRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -173,7 +173,7 @@ func (fc *FormHandler) Update(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	updatedForm, err := fc.formService.Update(formUUID, authUser, form.ToCreateFormInput(&request))
+	updatedForm, err := fh.formService.Update(formUUID, authUser, form.ToCreateFormInput(&request))
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -201,7 +201,7 @@ func (fc *FormHandler) Update(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /forms/{formUUID} [delete]
-func (fc *FormHandler) Delete(c echo.Context) error {
+func (fh *FormHandler) Delete(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -214,7 +214,7 @@ func (fc *FormHandler) Delete(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	if _, err := fc.formService.Delete(formUUID, authUser); err != nil {
+	if _, err := fh.formService.Delete(formUUID, authUser); err != nil {
 		return response.ErrorResponse(c, err)
 	}
 

--- a/internal/api/handlers/form.go
+++ b/internal/api/handlers/form.go
@@ -38,7 +38,7 @@ func NewFormHandler(injector *do.Injector) (*FormHandler, error) {
 // @Param sort query string false "Field to sort by"
 // @Param order query string false "Sort order (asc or desc)"
 //
-// @Success 200 {array} responses.Response{content=[]resources.FormResponse} "List of forms"
+// @Success 200 {array} response.Response{content=[]form.Response} "List of forms"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -74,7 +74,7 @@ func (fh *FormHandler) List(c echo.Context) error {
 //
 // @Param formUUID path string true "Form UUID"
 //
-// @Success 200 {object} responses.Response{content=resources.FormResponse} "Form details"
+// @Success 200 {object} response.Response{content=form.Response} "Form details"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -113,9 +113,9 @@ func (fh *FormHandler) Show(c echo.Context) error {
 // @Param Authorization header string true "Bearer Token"
 // @Param X-Project header string true "Project UUID"
 //
-// @Param form body form_requests.CreateRequest true "Form name and description"
+// @Param form body form.CreateRequest true "Form name and description"
 //
-// @Success 201 {object} responses.Response{content=resources.FormResponse} "Form created"
+// @Success 201 {object} response.Response{content=form.Response} "Form created"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
@@ -151,9 +151,9 @@ func (fh *FormHandler) Store(c echo.Context) error {
 // @Param X-Project header string true "Project UUID"
 //
 // @Param formUUID path string true "Form UUID"
-// @Param form body form_requests.CreateRequest true "Form name and description"
+// @Param form body form.CreateRequest true "Form name and description"
 //
-// @Success 200 {object} responses.Response{content=resources.FormResponse} "Form updated"
+// @Success 200 {object} response.Response{content=form.Response} "Form updated"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"

--- a/internal/api/handlers/form_field.go
+++ b/internal/api/handlers/form_field.go
@@ -39,7 +39,7 @@ func NewFormFieldHandler(injector *do.Injector) (*FormFieldHandler, error) {
 // @Failure 500 "Internal server error"
 //
 // @Router /forms/{formUUID}/fields [get]
-func (ffc *FormFieldHandler) List(c echo.Context) error {
+func (ffh *FormFieldHandler) List(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -52,7 +52,7 @@ func (ffc *FormFieldHandler) List(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	formFields, err := ffc.formFieldService.List(formUUID, authUser)
+	formFields, err := ffh.formFieldService.List(formUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -79,7 +79,7 @@ func (ffc *FormFieldHandler) List(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /forms/{formUUID}/fields/{fieldUUID} [get]
-func (ffc *FormFieldHandler) Show(c echo.Context) error {
+func (ffh *FormFieldHandler) Show(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -92,7 +92,7 @@ func (ffc *FormFieldHandler) Show(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	formField, err := ffc.formFieldService.GetByUUID(formUUID, authUser)
+	formField, err := ffh.formFieldService.GetByUUID(formUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -120,7 +120,7 @@ func (ffc *FormFieldHandler) Show(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /forms/{formUUID}/fields [post]
-func (ffc *FormFieldHandler) Store(c echo.Context) error {
+func (ffh *FormFieldHandler) Store(c echo.Context) error {
 	var request form.CreateFormFieldsRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -133,7 +133,7 @@ func (ffc *FormFieldHandler) Store(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	formFields, err := ffc.formFieldService.CreateMany(formUUID, form.ToCreateFormFieldInput(&request), authUser)
+	formFields, err := ffh.formFieldService.CreateMany(formUUID, form.ToCreateFormFieldInput(&request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -162,7 +162,7 @@ func (ffc *FormFieldHandler) Store(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /forms/{formUUID}/fields/{fieldUUID} [put]
-func (ffc *FormFieldHandler) Update(c echo.Context) error {
+func (ffh *FormFieldHandler) Update(c echo.Context) error {
 	var request form.UpdateFormFieldRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -180,7 +180,7 @@ func (ffc *FormFieldHandler) Update(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	updatedFormField, err := ffc.formFieldService.Update(formUUID, fieldUUID, authUser, form.ToUpdateFormFieldInput(&request))
+	updatedFormField, err := ffh.formFieldService.Update(formUUID, fieldUUID, authUser, form.ToUpdateFormFieldInput(&request))
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -207,7 +207,7 @@ func (ffc *FormFieldHandler) Update(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /forms/{formUUID}/fields/{fieldUUID} [delete]
-func (ffc *FormFieldHandler) Delete(c echo.Context) error {
+func (ffh *FormFieldHandler) Delete(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -225,7 +225,7 @@ func (ffc *FormFieldHandler) Delete(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	if _, err := ffc.formFieldService.Delete(formUUID, fieldUUID, authUser); err != nil {
+	if _, err := ffh.formFieldService.Delete(formUUID, fieldUUID, authUser); err != nil {
 		return response.ErrorResponse(c, err)
 	}
 

--- a/internal/api/handlers/form_field.go
+++ b/internal/api/handlers/form_field.go
@@ -33,7 +33,7 @@ func NewFormFieldHandler(injector *do.Injector) (*FormFieldHandler, error) {
 // @Param Authorization header string true "Bearer Token"
 // @Param formUUID path string true "Form UUID"
 //
-// @Success 200 {array} responses.Response{content=[]resources.FieldResponse} "List of fields"
+// @Success 200 {array} response.Response{content=[]form.FieldResponse} "List of fields"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -73,7 +73,7 @@ func (ffh *FormFieldHandler) List(c echo.Context) error {
 // @Param formUUID path string true "Form UUID"
 // @Param fieldUUID path string true "Field UUID"
 //
-// @Success 200 {object} responses.Response{content=resources.FieldResponse} "Field details"
+// @Success 200 {object} response.Response{content=form.FieldResponse} "Field details"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -110,10 +110,10 @@ func (ffh *FormFieldHandler) Show(c echo.Context) error {
 // @Produce json
 //
 // @Param Authorization header string true "Bearer Token"
-// @Param field body form_requests.CreateFormFieldsRequest true "Field details"
+// @Param field body form.CreateFormFieldsRequest true "Field details"
 // @Param formUUID path string true "Form UUID"
 //
-// @Success 201 {object} responses.Response{content=resources.FieldResponse} "Field created"
+// @Success 201 {object} response.Response{content=form.FieldResponse} "Field created"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
@@ -151,11 +151,11 @@ func (ffh *FormFieldHandler) Store(c echo.Context) error {
 // @Produce json
 //
 // @Param Authorization header string true "Bearer Token"
-// @Param field body form_requests.UpdateFormFieldRequest true "Field details"
+// @Param field body form.UpdateFormFieldRequest true "Field details"
 // @Param formUUID path string true "Form UUID"
 // @Param fieldUUID path string true "Field UUID"
 //
-// @Success 200 {object} responses.Response{content=resources.FieldResponse} "Field updated"
+// @Success 200 {object} response.Response{content=form.FieldResponse} "Field updated"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"

--- a/internal/api/handlers/form_field.go
+++ b/internal/api/handlers/form_field.go
@@ -33,7 +33,7 @@ func NewFormFieldHandler(injector *do.Injector) (*FormFieldHandler, error) {
 // @Param Authorization header string true "Bearer Token"
 // @Param formUUID path string true "Form UUID"
 //
-// @Success 200 {array} response.Response{content=[]form.FieldResponse} "List of fields"
+// @Success 200 {array} response.Response{content=[]form.FieldResponseApi} "List of fields"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -73,7 +73,7 @@ func (ffh *FormFieldHandler) List(c echo.Context) error {
 // @Param formUUID path string true "Form UUID"
 // @Param fieldUUID path string true "Field UUID"
 //
-// @Success 200 {object} response.Response{content=form.FieldResponse} "Field details"
+// @Success 200 {object} response.Response{content=form.FieldResponseApi} "Field details"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -113,7 +113,7 @@ func (ffh *FormFieldHandler) Show(c echo.Context) error {
 // @Param field body form.CreateFormFieldsRequest true "Field details"
 // @Param formUUID path string true "Form UUID"
 //
-// @Success 201 {object} response.Response{content=form.FieldResponse} "Field created"
+// @Success 201 {object} response.Response{content=form.FieldResponseApi} "Field created"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
@@ -155,7 +155,7 @@ func (ffh *FormFieldHandler) Store(c echo.Context) error {
 // @Param formUUID path string true "Form UUID"
 // @Param fieldUUID path string true "Field UUID"
 //
-// @Success 200 {object} response.Response{content=form.FieldResponse} "Field updated"
+// @Success 200 {object} response.Response{content=form.FieldResponseApi} "Field updated"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"

--- a/internal/api/handlers/form_response.go
+++ b/internal/api/handlers/form_response.go
@@ -41,7 +41,7 @@ func NewFormResponseHandler(injector *do.Injector) (*FormResponseHandler, error)
 // @Failure 500 "Internal server error"
 //
 // @Router /forms/{formUUID}/responses [get]
-func (ffc *FormResponseHandler) List(c echo.Context) error {
+func (ffh *FormResponseHandler) List(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -54,7 +54,7 @@ func (ffc *FormResponseHandler) List(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	formResponses, err := ffc.formResponseService.List(formUUID, authUser)
+	formResponses, err := ffh.formResponseService.List(formUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -83,7 +83,7 @@ func (ffc *FormResponseHandler) List(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /forms/{formUUID}/responses/{formResponseUUID} [get]
-func (ffc *FormResponseHandler) Show(c echo.Context) error {
+func (ffh *FormResponseHandler) Show(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -91,12 +91,12 @@ func (ffc *FormResponseHandler) Show(c echo.Context) error {
 
 	authUser, _ := auth.NewAuth(c).User()
 
-	formUUID, formResponseUUID, err := ffc.parseRequest(request, c)
+	formUUID, formResponseUUID, err := ffh.parseRequest(request, c)
 	if err != nil {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	formResponse, err := ffc.formResponseService.GetByUUID(formResponseUUID, formUUID, authUser)
+	formResponse, err := ffh.formResponseService.GetByUUID(formResponseUUID, formUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -126,7 +126,7 @@ func (ffc *FormResponseHandler) Show(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /forms/{formUUID}/responses [post]
-func (ffc *FormResponseHandler) Store(c echo.Context) error {
+func (ffh *FormResponseHandler) Store(c echo.Context) error {
 	var request form.CreateResponseRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -139,7 +139,7 @@ func (ffc *FormResponseHandler) Store(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	formResponse, err := ffc.formResponseService.Create(formUUID, form.ToCreateFormResponseInput(&request), authUser)
+	formResponse, err := ffh.formResponseService.Create(formUUID, form.ToCreateFormResponseInput(&request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -168,7 +168,7 @@ func (ffc *FormResponseHandler) Store(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /forms/{formUUID}/responses/{formResponseUUID} [delete]
-func (ffc *FormResponseHandler) Delete(c echo.Context) error {
+func (ffh *FormResponseHandler) Delete(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -176,19 +176,19 @@ func (ffc *FormResponseHandler) Delete(c echo.Context) error {
 
 	authUser, _ := auth.NewAuth(c).User()
 
-	formUUID, formResponseUUID, err := ffc.parseRequest(request, c)
+	formUUID, formResponseUUID, err := ffh.parseRequest(request, c)
 	if err != nil {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	if err = ffc.formResponseService.Delete(formUUID, formResponseUUID, authUser); err != nil {
+	if err = ffh.formResponseService.Delete(formUUID, formResponseUUID, authUser); err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
 	return response.DeletedResponse(c, nil)
 }
 
-func (ffc *FormResponseHandler) parseRequest(request dto.DefaultRequestWithProjectHeader, c echo.Context) (uuid.UUID, uuid.UUID, error) {
+func (ffh *FormResponseHandler) parseRequest(request dto.DefaultRequestWithProjectHeader, c echo.Context) (uuid.UUID, uuid.UUID, error) {
 	formUUID, err := request.GetUUIDPathParam(c, "formUUID", true)
 	if err != nil {
 		return uuid.Nil, uuid.Nil, err

--- a/internal/api/handlers/form_response.go
+++ b/internal/api/handlers/form_response.go
@@ -35,7 +35,7 @@ func NewFormResponseHandler(injector *do.Injector) (*FormResponseHandler, error)
 // @Param projectUUID path string true "Project UUID"
 // @Param formUUID path string true "Form UUID"
 //
-// @Success 200 {object} responses.Response{content=[]resources.FormResponseForAPI} "List of form responses"
+// @Success 200 {object} response.Response{content=[]resources.FormResponseForAPI} "List of form responses"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -77,7 +77,7 @@ func (ffh *FormResponseHandler) List(c echo.Context) error {
 // @Param formUUID path string true "Form UUID"
 // @Param formResponseUUID path string true "Form Response UUID"
 //
-// @Success 200 {object} responses.Response{content=resources.FormResponseForAPI} "Form response details"
+// @Success 200 {object} response.Response{content=resources.FormResponseForAPI} "Form response details"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -119,7 +119,7 @@ func (ffh *FormResponseHandler) Show(c echo.Context) error {
 //
 // @Param request body form_requests.CreateResponseRequest true "Request body to create a new form response"
 //
-// @Success 201 {object} responses.Response{content=resources.FormResponseForAPI} "Form response details"
+// @Success 201 {object} response.Response{content=resources.FormResponseForAPI} "Form response details"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"

--- a/internal/api/handlers/form_response.go
+++ b/internal/api/handlers/form_response.go
@@ -35,7 +35,7 @@ func NewFormResponseHandler(injector *do.Injector) (*FormResponseHandler, error)
 // @Param projectUUID path string true "Project UUID"
 // @Param formUUID path string true "Form UUID"
 //
-// @Success 200 {object} response.Response{content=[]resources.FormResponseForAPI} "List of form responses"
+// @Success 200 {object} response.Response{content=[]form.ResponseForAPI} "List of form responses"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -77,7 +77,7 @@ func (ffh *FormResponseHandler) List(c echo.Context) error {
 // @Param formUUID path string true "Form UUID"
 // @Param formResponseUUID path string true "Form Response UUID"
 //
-// @Success 200 {object} response.Response{content=resources.FormResponseForAPI} "Form response details"
+// @Success 200 {object} response.Response{content=form.ResponseForAPI} "Form response details"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -117,9 +117,9 @@ func (ffh *FormResponseHandler) Show(c echo.Context) error {
 // @Param projectUUID path string true "Project UUID"
 // @Param formUUID path string true "Form UUID"
 //
-// @Param request body form_requests.CreateResponseRequest true "Request body to create a new form response"
+// @Param request body form.CreateResponseRequest true "Request body to create a new form response"
 //
-// @Success 201 {object} response.Response{content=resources.FormResponseForAPI} "Form response details"
+// @Success 201 {object} response.Response{content=form.ResponseForAPI} "Form response details"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"

--- a/internal/api/handlers/function.go
+++ b/internal/api/handlers/function.go
@@ -36,7 +36,7 @@ func NewFunctionHandler(injector *do.Injector) (*FunctionHandler, error) {
 // @Param projectUUID path string true "Project UUID"
 // @Param schema path string true "Schema to search under"
 //
-// @Success 200 {array} responses.Response{content=[]resources.FunctionResponse} "List of functions"
+// @Success 200 {array} response.Response{content=[]resources.FunctionResponse} "List of functions"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -78,7 +78,7 @@ func (fh *FunctionHandler) List(c echo.Context) error {
 // @Param schema path string true "Schema name"
 // @Param functionName path string true "Function name"
 //
-// @Success 200 {object} responses.Response{content=resources.FunctionResponse} "Function details"
+// @Success 200 {object} response.Response{content=resources.FunctionResponse} "Function details"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -124,7 +124,7 @@ func (fh *FunctionHandler) Show(c echo.Context) error {
 //
 // @Param form body requests.CreateFunctionRequest true "Function details"
 //
-// @Success 201 {object} responses.Response{content=resources.FunctionResponse} "Function created"
+// @Success 201 {object} response.Response{content=resources.FunctionResponse} "Function created"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"

--- a/internal/api/handlers/function.go
+++ b/internal/api/handlers/function.go
@@ -36,7 +36,7 @@ func NewFunctionHandler(injector *do.Injector) (*FunctionHandler, error) {
 // @Param projectUUID path string true "Project UUID"
 // @Param schema path string true "Schema to search under"
 //
-// @Success 200 {array} response.Response{content=[]resources.FunctionResponse} "List of functions"
+// @Success 200 {array} response.Response{content=[]database.FunctionResponse} "List of functions"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -78,7 +78,7 @@ func (fh *FunctionHandler) List(c echo.Context) error {
 // @Param schema path string true "Schema name"
 // @Param functionName path string true "Function name"
 //
-// @Success 200 {object} response.Response{content=resources.FunctionResponse} "Function details"
+// @Success 200 {object} response.Response{content=database.FunctionResponse} "Function details"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -122,9 +122,9 @@ func (fh *FunctionHandler) Show(c echo.Context) error {
 // @Param Authorization header string true "Bearer Token"
 // @Param Header X-Project header string true "Project UUID"
 //
-// @Param form body requests.CreateFunctionRequest true "Function details"
+// @Param function body database.CreateFunctionRequest true "Function details"
 //
-// @Success 201 {object} response.Response{content=resources.FunctionResponse} "Function created"
+// @Success 201 {object} response.Response{content=database.FunctionResponse} "Function created"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"

--- a/internal/api/handlers/function.go
+++ b/internal/api/handlers/function.go
@@ -42,7 +42,7 @@ func NewFunctionHandler(injector *do.Injector) (*FunctionHandler, error) {
 // @Failure 500 "Internal server error"
 //
 // @Router /functions/{schema} [get]
-func (fc *FunctionHandler) List(c echo.Context) error {
+func (fh *FunctionHandler) List(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -55,7 +55,7 @@ func (fc *FunctionHandler) List(c echo.Context) error {
 		return response.BadRequestResponse(c, "Schema is required")
 	}
 
-	functions, err := fc.functionService.List(schema, request.ProjectUUID, authUser)
+	functions, err := fh.functionService.List(schema, request.ProjectUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -84,7 +84,7 @@ func (fc *FunctionHandler) List(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /functions/{schema}/{functionName} [get]
-func (fc *FunctionHandler) Show(c echo.Context) error {
+func (fh *FunctionHandler) Show(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -102,7 +102,7 @@ func (fc *FunctionHandler) Show(c echo.Context) error {
 		return response.BadRequestResponse(c, "Function name is required")
 	}
 
-	fetchedFunction, err := fc.functionService.GetByName(functionName, schema, request.ProjectUUID, authUser)
+	fetchedFunction, err := fh.functionService.GetByName(functionName, schema, request.ProjectUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -131,7 +131,7 @@ func (fc *FunctionHandler) Show(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /functions/{schema} [post]
-func (fc *FunctionHandler) Store(c echo.Context) error {
+func (fh *FunctionHandler) Store(c echo.Context) error {
 	var request database.CreateFunctionRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -144,7 +144,7 @@ func (fc *FunctionHandler) Store(c echo.Context) error {
 		return response.BadRequestResponse(c, "Schema is required")
 	}
 
-	createdFunction, err := fc.functionService.Create(schema, database.ToCreateFunctionInput(request), authUser)
+	createdFunction, err := fh.functionService.Create(schema, database.ToCreateFunctionInput(request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -174,7 +174,7 @@ func (fc *FunctionHandler) Store(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /functions/{schema}/{functionName} [delete]
-func (fc *FunctionHandler) Delete(c echo.Context) error {
+func (fh *FunctionHandler) Delete(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -192,7 +192,7 @@ func (fc *FunctionHandler) Delete(c echo.Context) error {
 		return response.BadRequestResponse(c, "Function name is required")
 	}
 
-	if _, err := fc.functionService.Delete(schema, functionName, request.ProjectUUID, authUser); err != nil {
+	if _, err := fh.functionService.Delete(schema, functionName, request.ProjectUUID, authUser); err != nil {
 		return response.ErrorResponse(c, err)
 	}
 

--- a/internal/api/handlers/health.go
+++ b/internal/api/handlers/health.go
@@ -18,7 +18,7 @@ func NewHealthHandler(injector *do.Injector) (*HealthHandler, error) {
 	return &HealthHandler{settingService: settingService}, nil
 }
 
-func (hc *HealthHandler) Pulse(c echo.Context) error {
+func (hh *HealthHandler) Pulse(c echo.Context) error {
 	_, err := auth.NewAuth(c).User()
 	if err != nil {
 		return response.UnauthorizedResponse(c, err.Error())

--- a/internal/api/handlers/index.go
+++ b/internal/api/handlers/index.go
@@ -38,7 +38,7 @@ func NewIndexHandler(injector *do.Injector) (*IndexHandler, error) {
 // @Failure 500 "Internal server error"
 //
 // @Router /tables/{tableUUID}/indexes [get]
-func (ic *IndexHandler) List(c echo.Context) error {
+func (ih *IndexHandler) List(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -51,7 +51,7 @@ func (ic *IndexHandler) List(c echo.Context) error {
 		return response.BadRequestResponse(c, "Table name is required")
 	}
 
-	indexes, err := ic.indexService.List(fullTableName, request.ProjectUUID, authUser)
+	indexes, err := ih.indexService.List(fullTableName, request.ProjectUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -61,8 +61,8 @@ func (ic *IndexHandler) List(c echo.Context) error {
 
 // Show Index
 //
-// @Summary Show details of a specific index
-// @Description Retrieve details for a specific index in a table.
+// @Summary Show details of a specifih index
+// @Description Retrieve details for a specifih index in a table.
 // @Tags Indexes
 //
 // @Accept json
@@ -79,7 +79,7 @@ func (ic *IndexHandler) List(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /tables/{tableUUID}/indexes/{indexName} [get]
-func (ic *IndexHandler) Show(c echo.Context) error {
+func (ih *IndexHandler) Show(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -94,7 +94,7 @@ func (ic *IndexHandler) Show(c echo.Context) error {
 
 	indexName := c.Param("indexName")
 
-	index, err := ic.indexService.GetByName(indexName, fullTableName, request.ProjectUUID, authUser)
+	index, err := ih.indexService.GetByName(indexName, fullTableName, request.ProjectUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -122,7 +122,7 @@ func (ic *IndexHandler) Show(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /tables/{tableUUID}/indexes [post]
-func (ic *IndexHandler) Store(c echo.Context) error {
+func (ih *IndexHandler) Store(c echo.Context) error {
 	var request databaseDto.CreateIndexRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -135,7 +135,7 @@ func (ic *IndexHandler) Store(c echo.Context) error {
 		return response.BadRequestResponse(c, "Table name is required")
 	}
 
-	index, err := ic.indexService.Create(fullTableName, databaseDto.ToCreateIndexInput(request), authUser)
+	index, err := ih.indexService.Create(fullTableName, databaseDto.ToCreateIndexInput(request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -163,7 +163,7 @@ func (ic *IndexHandler) Store(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /tables/{tableUUID}/indexes/{indexName} [delete]
-func (ic *IndexHandler) Delete(c echo.Context) error {
+func (ih *IndexHandler) Delete(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -178,7 +178,7 @@ func (ic *IndexHandler) Delete(c echo.Context) error {
 
 	indexName := c.Param("indexName")
 
-	if _, err := ic.indexService.Delete(indexName, fullTableName, request.ProjectUUID, authUser); err != nil {
+	if _, err := ih.indexService.Delete(indexName, fullTableName, request.ProjectUUID, authUser); err != nil {
 		return response.ErrorResponse(c, err)
 	}
 

--- a/internal/api/handlers/index.go
+++ b/internal/api/handlers/index.go
@@ -32,7 +32,7 @@ func NewIndexHandler(injector *do.Injector) (*IndexHandler, error) {
 // @Param Authorization header string true "Bearer Token"
 // @Param tableUUID path string true "Table UUID"
 //
-// @Success 200 {object} responses.Response{content=[]resources.GenericResponse} "List of indexes"
+// @Success 200 {object} response.Response{content=[]dto.GenericResponse} "List of indexes"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -61,8 +61,8 @@ func (ih *IndexHandler) List(c echo.Context) error {
 
 // Show Index
 //
-// @Summary Show details of a specifih index
-// @Description Retrieve details for a specifih index in a table.
+// @Summary Show details of a specific index
+// @Description Retrieve details for a specific index in a table.
 // @Tags Indexes
 //
 // @Accept json
@@ -72,7 +72,7 @@ func (ih *IndexHandler) List(c echo.Context) error {
 // @Param tableUUID path string true "Table UUID"
 // @Param index_name path string true "Index Name"
 //
-// @Success 200 {object} responses.Response{content=resources.GenericResponse} "Index details"
+// @Success 200 {object} response.Response{content=dto.GenericResponse} "Index details"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 404 "Index not found"
@@ -113,9 +113,9 @@ func (ih *IndexHandler) Show(c echo.Context) error {
 //
 // @Param Authorization header string true "Bearer Token"
 // @Param tableUUID path string true "Table UUID"
-// @Param index body requests.IndexCreateRequest true "Index details JSON"
+// @Param index body database.CreateIndexRequest true "Index details JSON"
 //
-// @Success 201 {object} responses.Response{content=resources.GenericResponse} "Index created"
+// @Success 201 {object} response.Response{content=dto.GenericResponse} "Index created"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 422 "Unprocessable entity"

--- a/internal/api/handlers/log.go
+++ b/internal/api/handlers/log.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	"fluxton/internal/api/dto"
+	"fluxton/internal/api/dto/logging"
 	logMapper "fluxton/internal/api/mapper/logging"
 	"fluxton/internal/api/response"
 	logDomain "fluxton/internal/domain/logging"
@@ -43,7 +43,7 @@ func NewLogHandler(injector *do.Injector) (*LogHandler, error) {
 //
 // @Router /admin/logs [get]
 func (lh *LogHandler) List(c echo.Context) error {
-	var request dto.DefaultRequest
+	var request logging.ListRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}

--- a/internal/api/handlers/log.go
+++ b/internal/api/handlers/log.go
@@ -36,7 +36,7 @@ func NewLogHandler(injector *do.Injector) (*LogHandler, error) {
 // @Param sort query string false "Field to sort by"
 // @Param order query string false "Sort order (asc or desc)"
 //
-// @Success 200 {array} response.Response{content=[]resources.FileResponse} "List of files"
+// @Success 200 {array} response.Response{content=[]logging.Response} "List of files"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"

--- a/internal/api/handlers/log.go
+++ b/internal/api/handlers/log.go
@@ -36,7 +36,7 @@ func NewLogHandler(injector *do.Injector) (*LogHandler, error) {
 // @Param sort query string false "Field to sort by"
 // @Param order query string false "Sort order (asc or desc)"
 //
-// @Success 200 {array} responses.Response{content=[]resources.FileResponse} "List of files"
+// @Success 200 {array} response.Response{content=[]resources.FileResponse} "List of files"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"

--- a/internal/api/handlers/log.go
+++ b/internal/api/handlers/log.go
@@ -1,0 +1,60 @@
+package handlers
+
+import (
+	"fluxton/internal/api/dto"
+	logMapper "fluxton/internal/api/mapper/logging"
+	"fluxton/internal/api/response"
+	logDomain "fluxton/internal/domain/logging"
+	"fluxton/pkg/auth"
+	"github.com/labstack/echo/v4"
+	"github.com/samber/do"
+)
+
+type LogHandler struct {
+	logService logDomain.Service
+}
+
+func NewLogHandler(injector *do.Injector) (*LogHandler, error) {
+	logService := do.MustInvoke[logDomain.Service](injector)
+
+	return &LogHandler{logService: logService}, nil
+}
+
+// List all logs
+//
+// @Summary List all logs
+// @Description Get all logs
+// @Tags Logs
+//
+// @Accept json
+// @Produce json
+//
+// @Param Authorization header string true "Bearer Token"
+//
+// @Param page query string false "Page number for pagination"
+// @Param limit query string false "Number of items per page"
+// @Param sort query string false "Field to sort by"
+// @Param order query string false "Sort order (asc or desc)"
+//
+// @Success 200 {array} responses.Response{content=[]resources.FileResponse} "List of files"
+// @Failure 400 "Invalid input"
+// @Failure 401 "Unauthorized"
+// @Failure 500 "Internal server error"
+//
+// @Router /admin/logs [get]
+func (lh *LogHandler) List(c echo.Context) error {
+	var request dto.DefaultRequest
+	if err := request.BindAndValidate(c); err != nil {
+		return response.UnprocessableResponse(c, err)
+	}
+
+	authUser, _ := auth.NewAuth(c).User()
+
+	paginationParams := request.ExtractPaginationParams(c)
+	logs, err := lh.logService.List(paginationParams, authUser)
+	if err != nil {
+		return response.ErrorResponse(c, err)
+	}
+
+	return response.SuccessResponse(c, logMapper.ToResourceCollection(logs))
+}

--- a/internal/api/handlers/organization.go
+++ b/internal/api/handlers/organization.go
@@ -37,7 +37,7 @@ func NewOrganizationHandler(injector *do.Injector) (*OrganizationHandler, error)
 // @Param sort query string false "Field to sort by"
 // @Param order query string false "Sort order (asc or desc)"
 //
-// @Success 200 {object} responses.Response{content=[]organizationDto.Response} "List of organizations"
+// @Success 200 {object} response.Response{content=[]organizationDto.Response} "List of organizations"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
 //
@@ -71,7 +71,7 @@ func (oh *OrganizationHandler) List(c echo.Context) error {
 // @Param Authorization header string true "Bearer Token"
 // @Param organization_id path string true "Organization ID"
 //
-// @Success 200 {object} responses.Response{content=organizationDto.Response} "Organization details"
+// @Success 200 {object} response.Response{content=organizationDto.Response} "Organization details"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
@@ -111,7 +111,7 @@ func (oh *OrganizationHandler) Show(c echo.Context) error {
 // @Param Authorization header string true "Bearer Token"
 // @Param organization body organization_requests.CreateRequest true "Organization name"
 //
-// @Success 201 {object} responses.Response{content=organizationDto.Response} "Organization created"
+// @Success 201 {object} response.Response{content=organizationDto.Response} "Organization created"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
@@ -150,7 +150,7 @@ func (oh *OrganizationHandler) Store(c echo.Context) error {
 // @Param organization_id path string true "Organization ID"
 // @Param organization body organization_requests.CreateRequest true "Updated organization details"
 //
-// @Success 200 {object} responses.Response{content=organizationDto.Response} "Organization updated"
+// @Success 200 {object} response.Response{content=organizationDto.Response} "Organization updated"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
@@ -190,7 +190,7 @@ func (oh *OrganizationHandler) Update(c echo.Context) error {
 // @Param Authorization header string true "Bearer Token"
 // @Param organization_id path string true "Organization ID"
 //
-// @Success 204 {object} responses.Response{} "Organization deleted"
+// @Success 204 {object} response.Response{} "Organization deleted"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
 //

--- a/internal/api/handlers/organization.go
+++ b/internal/api/handlers/organization.go
@@ -42,7 +42,7 @@ func NewOrganizationHandler(injector *do.Injector) (*OrganizationHandler, error)
 // @Failure 500 "Internal server error"
 //
 // @Router /organizations [get]
-func (oc *OrganizationHandler) List(c echo.Context) error {
+func (oh *OrganizationHandler) List(c echo.Context) error {
 	var request dto.DefaultRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -51,7 +51,7 @@ func (oc *OrganizationHandler) List(c echo.Context) error {
 	authUserId, _ := auth.NewAuth(c).Uuid()
 
 	paginationParams := request.ExtractPaginationParams(c)
-	organizations, err := oc.organizationService.List(paginationParams, authUserId)
+	organizations, err := oh.organizationService.List(paginationParams, authUserId)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -78,7 +78,7 @@ func (oc *OrganizationHandler) List(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /organizations/{organizationUUID} [get]
-func (oc *OrganizationHandler) Show(c echo.Context) error {
+func (oh *OrganizationHandler) Show(c echo.Context) error {
 	var request dto.DefaultRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -91,7 +91,7 @@ func (oc *OrganizationHandler) Show(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	organization, err := oc.organizationService.GetByID(organizationUUID, authUser)
+	organization, err := oh.organizationService.GetByID(organizationUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -118,7 +118,7 @@ func (oc *OrganizationHandler) Show(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /organizations [post]
-func (oc *OrganizationHandler) Store(c echo.Context) error {
+func (oh *OrganizationHandler) Store(c echo.Context) error {
 	var request organizationDto.CreateRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -129,7 +129,7 @@ func (oc *OrganizationHandler) Store(c echo.Context) error {
 		return response.UnauthorizedResponse(c, err.Error())
 	}
 
-	organization, err := oc.organizationService.Create(request.Name, authUser)
+	organization, err := oh.organizationService.Create(request.Name, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -157,7 +157,7 @@ func (oc *OrganizationHandler) Store(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /organizations/{organizationUUID} [put]
-func (oc *OrganizationHandler) Update(c echo.Context) error {
+func (oh *OrganizationHandler) Update(c echo.Context) error {
 	var request organizationDto.CreateRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -170,7 +170,7 @@ func (oc *OrganizationHandler) Update(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	updatedOrganization, err := oc.organizationService.Update(request.Name, organizationUUID, authUser)
+	updatedOrganization, err := oh.organizationService.Update(request.Name, organizationUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -195,7 +195,7 @@ func (oc *OrganizationHandler) Update(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /organizations/{organizationUUID} [delete]
-func (oc *OrganizationHandler) Delete(c echo.Context) error {
+func (oh *OrganizationHandler) Delete(c echo.Context) error {
 	var request dto.DefaultRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -208,7 +208,7 @@ func (oc *OrganizationHandler) Delete(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	if _, err := oc.organizationService.Delete(organizationUUID, authUser); err != nil {
+	if _, err := oh.organizationService.Delete(organizationUUID, authUser); err != nil {
 		return response.ErrorResponse(c, err)
 	}
 

--- a/internal/api/handlers/organization.go
+++ b/internal/api/handlers/organization.go
@@ -37,7 +37,7 @@ func NewOrganizationHandler(injector *do.Injector) (*OrganizationHandler, error)
 // @Param sort query string false "Field to sort by"
 // @Param order query string false "Sort order (asc or desc)"
 //
-// @Success 200 {object} response.Response{content=[]organizationDto.Response} "List of organizations"
+// @Success 200 {object} response.Response{content=[]organization.Response} "List of organizations"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
 //
@@ -71,7 +71,7 @@ func (oh *OrganizationHandler) List(c echo.Context) error {
 // @Param Authorization header string true "Bearer Token"
 // @Param organization_id path string true "Organization ID"
 //
-// @Success 200 {object} response.Response{content=organizationDto.Response} "Organization details"
+// @Success 200 {object} response.Response{content=organization.Response} "Organization details"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
@@ -109,9 +109,9 @@ func (oh *OrganizationHandler) Show(c echo.Context) error {
 // @Produce json
 //
 // @Param Authorization header string true "Bearer Token"
-// @Param organization body organization_requests.CreateRequest true "Organization name"
+// @Param organization body organization.CreateRequest true "Organization name"
 //
-// @Success 201 {object} response.Response{content=organizationDto.Response} "Organization created"
+// @Success 201 {object} response.Response{content=organization.Response} "Organization created"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
@@ -148,9 +148,9 @@ func (oh *OrganizationHandler) Store(c echo.Context) error {
 //
 // @Param Authorization header string true "Bearer Token"
 // @Param organization_id path string true "Organization ID"
-// @Param organization body organization_requests.CreateRequest true "Updated organization details"
+// @Param organization body organization.CreateRequest true "Updated organization details"
 //
-// @Success 200 {object} response.Response{content=organizationDto.Response} "Organization updated"
+// @Success 200 {object} response.Response{content=organization.Response} "Organization updated"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"

--- a/internal/api/handlers/organization_member.go
+++ b/internal/api/handlers/organization_member.go
@@ -33,7 +33,7 @@ func NewOrganizationMemberHandler(injector *do.Injector) (*OrganizationMemberHan
 // @Param Authorization header string true "Bearer Token"
 // @Param organization_id path string true "Organization ID"
 //
-// @Success 201 {object} responses.Response{content=[]resources.UserResponse} "User created"
+// @Success 201 {object} response.Response{content=[]resources.UserResponse} "User created"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
@@ -74,7 +74,7 @@ func (omh *OrganizationMemberHandler) List(c echo.Context) error {
 // @Param organization_id path string true "Organization ID"
 // @Param user body organization_requests.MemberCreateRequest true "User ID JSON"
 //
-// @Success 201 {object} responses.Response{content=resources.UserResponse} "User created"
+// @Success 201 {object} response.Response{content=resources.UserResponse} "User created"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"

--- a/internal/api/handlers/organization_member.go
+++ b/internal/api/handlers/organization_member.go
@@ -40,7 +40,7 @@ func NewOrganizationMemberHandler(injector *do.Injector) (*OrganizationMemberHan
 // @Failure 500 "Internal server error"
 //
 // @Router /organizations/{organizationUUID}/users [get]
-func (ouc *OrganizationMemberHandler) List(c echo.Context) error {
+func (omh *OrganizationMemberHandler) List(c echo.Context) error {
 	var request dto.DefaultRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -53,7 +53,7 @@ func (ouc *OrganizationMemberHandler) List(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	organizationUsers, err := ouc.organizationService.ListUsers(organizationUUID, authUser)
+	organizationUsers, err := omh.organizationService.ListUsers(organizationUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -81,7 +81,7 @@ func (ouc *OrganizationMemberHandler) List(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /organizations/{organizationUUID}/users [post]
-func (ouc *OrganizationMemberHandler) Store(c echo.Context) error {
+func (omh *OrganizationMemberHandler) Store(c echo.Context) error {
 	var request organizationDto.MemberCreateRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -94,7 +94,7 @@ func (ouc *OrganizationMemberHandler) Store(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	organizationUser, err := ouc.organizationService.CreateUser(request.UserID, organizationUUID, authUser)
+	organizationUser, err := omh.organizationService.CreateUser(request.UserID, organizationUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -122,7 +122,7 @@ func (ouc *OrganizationMemberHandler) Store(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /organizations/{organizationUUID}/users/{userUUID} [delete]
-func (ouc *OrganizationMemberHandler) Delete(c echo.Context) error {
+func (omh *OrganizationMemberHandler) Delete(c echo.Context) error {
 	var request dto.DefaultRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -140,7 +140,7 @@ func (ouc *OrganizationMemberHandler) Delete(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	if err := ouc.organizationService.DeleteUser(organizationUUID, userID, authUser); err != nil {
+	if err := omh.organizationService.DeleteUser(organizationUUID, userID, authUser); err != nil {
 		return response.ErrorResponse(c, err)
 	}
 

--- a/internal/api/handlers/organization_member.go
+++ b/internal/api/handlers/organization_member.go
@@ -33,7 +33,7 @@ func NewOrganizationMemberHandler(injector *do.Injector) (*OrganizationMemberHan
 // @Param Authorization header string true "Bearer Token"
 // @Param organization_id path string true "Organization ID"
 //
-// @Success 201 {object} response.Response{content=[]resources.UserResponse} "User created"
+// @Success 201 {object} response.Response{content=[]user.Response} "User created"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
@@ -72,9 +72,9 @@ func (omh *OrganizationMemberHandler) List(c echo.Context) error {
 //
 // @Param Authorization header string true "Bearer Token"
 // @Param organization_id path string true "Organization ID"
-// @Param user body organization_requests.MemberCreateRequest true "User ID JSON"
+// @Param user body organization.MemberCreateRequest true "User ID JSON"
 //
-// @Success 201 {object} response.Response{content=resources.UserResponse} "User created"
+// @Success 201 {object} response.Response{content=user.Response} "User created"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"

--- a/internal/api/handlers/project.go
+++ b/internal/api/handlers/project.go
@@ -38,7 +38,7 @@ func NewProjectHandler(injector *do.Injector) (*ProjectHandler, error) {
 // @Param sort query string false "Field to sort by"
 // @Param order query string false "Sort order (asc or desc)"
 //
-// @Success 200 {object} responses.Response{content=[]resources.ProjectResponse} "List of projects"
+// @Success 200 {object} response.Response{content=[]resources.ProjectResponse} "List of projects"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -78,7 +78,7 @@ func (ph *ProjectHandler) List(c echo.Context) error {
 // @Param Authorization header string true "Bearer Token"
 // @Param projectUUID path string true "Project UUID"
 //
-// @Success 200 {object} responses.Response{content=resources.ProjectResponse} "Project details"
+// @Success 200 {object} response.Response{content=resources.ProjectResponse} "Project details"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
@@ -119,7 +119,7 @@ func (ph *ProjectHandler) Show(c echo.Context) error {
 // @Param organizationUUID query string true "Organization UUID"
 // @Param name body project_requests.CreateRequest true "Project name"
 //
-// @Success 201 {object} responses.Response{content=resources.ProjectResponse} "Project details"
+// @Success 201 {object} response.Response{content=resources.ProjectResponse} "Project details"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
@@ -155,7 +155,7 @@ func (ph *ProjectHandler) Store(c echo.Context) error {
 // @Param projectUUID path string true "Project UUID"
 // @Param name body project_requests.UpdateRequest true "Project name"
 //
-// @Success 200 {object} responses.Response{content=resources.ProjectResponse} "Project details"
+// @Success 200 {object} response.Response{content=resources.ProjectResponse} "Project details"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
@@ -195,7 +195,7 @@ func (ph *ProjectHandler) Update(c echo.Context) error {
 // @Param Authorization header string true "Bearer Token"
 // @Param projectUUID path string true "Project UUID"
 //
-// @Success 200 {object} responses.Response{} "Project deleted"
+// @Success 200 {object} response.Response{} "Project deleted"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"

--- a/internal/api/handlers/project.go
+++ b/internal/api/handlers/project.go
@@ -44,7 +44,7 @@ func NewProjectHandler(injector *do.Injector) (*ProjectHandler, error) {
 // @Failure 500 "Internal server error"
 //
 // @Router /projects [get]
-func (pc *ProjectHandler) List(c echo.Context) error {
+func (ph *ProjectHandler) List(c echo.Context) error {
 	var request dto.DefaultRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -58,7 +58,7 @@ func (pc *ProjectHandler) List(c echo.Context) error {
 	}
 
 	paginationParams := request.ExtractPaginationParams(c)
-	projects, err := pc.projectService.List(paginationParams, organizationUUID, authUser)
+	projects, err := ph.projectService.List(paginationParams, organizationUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -85,7 +85,7 @@ func (pc *ProjectHandler) List(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /projects/{projectUUID} [get]
-func (pc *ProjectHandler) Show(c echo.Context) error {
+func (ph *ProjectHandler) Show(c echo.Context) error {
 	var request dto.DefaultRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -98,7 +98,7 @@ func (pc *ProjectHandler) Show(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	fetchedProject, err := pc.projectService.GetByUUID(projectUUID, authUser)
+	fetchedProject, err := ph.projectService.GetByUUID(projectUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -126,7 +126,7 @@ func (pc *ProjectHandler) Show(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /projects [post]
-func (pc *ProjectHandler) Store(c echo.Context) error {
+func (ph *ProjectHandler) Store(c echo.Context) error {
 	var request project.CreateRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -134,7 +134,7 @@ func (pc *ProjectHandler) Store(c echo.Context) error {
 
 	authUser, _ := auth.NewAuth(c).User()
 
-	updatedProject, err := pc.projectService.Create(project.ToCreateProjectInput(&request), authUser)
+	updatedProject, err := ph.projectService.Create(project.ToCreateProjectInput(&request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -162,7 +162,7 @@ func (pc *ProjectHandler) Store(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /projects/{projectUUID} [put]
-func (pc *ProjectHandler) Update(c echo.Context) error {
+func (ph *ProjectHandler) Update(c echo.Context) error {
 	var request project.UpdateRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -175,7 +175,7 @@ func (pc *ProjectHandler) Update(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	updatedOrganization, err := pc.projectService.Update(projectUUID, authUser, project.ToUpdateProjectInput(&request))
+	updatedOrganization, err := ph.projectService.Update(projectUUID, authUser, project.ToUpdateProjectInput(&request))
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -201,7 +201,7 @@ func (pc *ProjectHandler) Update(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /projects/{projectUUID} [delete]
-func (pc *ProjectHandler) Delete(c echo.Context) error {
+func (ph *ProjectHandler) Delete(c echo.Context) error {
 	var request dto.DefaultRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -214,7 +214,7 @@ func (pc *ProjectHandler) Delete(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	if _, err := pc.projectService.Delete(projectUUID, authUser); err != nil {
+	if _, err := ph.projectService.Delete(projectUUID, authUser); err != nil {
 		return response.ErrorResponse(c, err)
 	}
 

--- a/internal/api/handlers/project.go
+++ b/internal/api/handlers/project.go
@@ -38,7 +38,7 @@ func NewProjectHandler(injector *do.Injector) (*ProjectHandler, error) {
 // @Param sort query string false "Field to sort by"
 // @Param order query string false "Sort order (asc or desc)"
 //
-// @Success 200 {object} response.Response{content=[]resources.ProjectResponse} "List of projects"
+// @Success 200 {object} response.Response{content=[]project.Response} "List of projects"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -78,7 +78,7 @@ func (ph *ProjectHandler) List(c echo.Context) error {
 // @Param Authorization header string true "Bearer Token"
 // @Param projectUUID path string true "Project UUID"
 //
-// @Success 200 {object} response.Response{content=resources.ProjectResponse} "Project details"
+// @Success 200 {object} response.Response{content=project.Response} "Project details"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
@@ -117,9 +117,9 @@ func (ph *ProjectHandler) Show(c echo.Context) error {
 //
 // @Param Authorization header string true "Bearer Token"
 // @Param organizationUUID query string true "Organization UUID"
-// @Param name body project_requests.CreateRequest true "Project name"
+// @Param name body project.CreateRequest true "Project name"
 //
-// @Success 201 {object} response.Response{content=resources.ProjectResponse} "Project details"
+// @Success 201 {object} response.Response{content=project.Response} "Project details"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
@@ -153,9 +153,9 @@ func (ph *ProjectHandler) Store(c echo.Context) error {
 //
 // @Param Authorization header string true "Bearer Token"
 // @Param projectUUID path string true "Project UUID"
-// @Param name body project_requests.UpdateRequest true "Project name"
+// @Param name body project.UpdateRequest true "Project name"
 //
-// @Success 200 {object} response.Response{content=resources.ProjectResponse} "Project details"
+// @Success 200 {object} response.Response{content=project.Response} "Project details"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"

--- a/internal/api/handlers/setting.go
+++ b/internal/api/handlers/setting.go
@@ -20,8 +20,8 @@ func NewSettingHandler(injector *do.Injector) (*SettingHandler, error) {
 	return &SettingHandler{settingService: settingService}, nil
 }
 
-func (sc *SettingHandler) List(c echo.Context) error {
-	settings, err := sc.settingService.List()
+func (sh *SettingHandler) List(c echo.Context) error {
+	settings, err := sh.settingService.List()
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -29,7 +29,7 @@ func (sc *SettingHandler) List(c echo.Context) error {
 	return response.SuccessResponse(c, settingMapper.ToResourceCollection(settings))
 }
 
-func (sc *SettingHandler) Update(c echo.Context) error {
+func (sh *SettingHandler) Update(c echo.Context) error {
 	var request setting.UpdateRequest
 	authUser, _ := auth.NewAuth(c).User()
 
@@ -37,7 +37,7 @@ func (sc *SettingHandler) Update(c echo.Context) error {
 		return response.UnprocessableResponse(c, err)
 	}
 
-	updatedSettings, err := sc.settingService.Update(authUser, &request)
+	updatedSettings, err := sh.settingService.Update(authUser, &request)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -45,10 +45,10 @@ func (sc *SettingHandler) Update(c echo.Context) error {
 	return response.SuccessResponse(c, settingMapper.ToResourceCollection(updatedSettings))
 }
 
-func (sc *SettingHandler) Reset(c echo.Context) error {
+func (sh *SettingHandler) Reset(c echo.Context) error {
 	authUser, _ := auth.NewAuth(c).User()
 
-	updatedSettings, err := sc.settingService.Reset(authUser)
+	updatedSettings, err := sh.settingService.Reset(authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}

--- a/internal/api/handlers/table.go
+++ b/internal/api/handlers/table.go
@@ -33,7 +33,7 @@ func NewTableHandler(injector *do.Injector) (*TableHandler, error) {
 // @Param Authorization header string true "Bearer Token"
 // @param Header X-Project header string true "Project UUID"
 //
-// @Success 200 {object} response.Response{content=[]resources.TableResponse} "List of tables"
+// @Success 200 {object} response.Response{content=[]database.TableResponse} "List of tables"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -69,7 +69,7 @@ func (th *TableHandler) List(c echo.Context) error {
 //
 // @Param tableUUID path string true "Table UUID"
 //
-// @Success 200 {object} response.Response{content=resources.TableResponse} "Table details"
+// @Success 200 {object} response.Response{content=database.TableResponse} "Table details"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 404 "Table not found"
@@ -109,9 +109,9 @@ func (th *TableHandler) Show(c echo.Context) error {
 // @Param Authorization header string true "Bearer Token"
 // @param Header X-Project header string true "Project UUID"
 //
-// @Param table body table_requests.CreateRequest true "Table definition JSON"
+// @Param table body database.CreateTableRequest true "Table definition JSON"
 //
-// @Success 201 {object} response.Response{content=resources.TableResponse} "Table created"
+// @Success 201 {object} response.Response{content=database.TableResponse} "Table created"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 422 "Unprocessable entity"
@@ -146,9 +146,9 @@ func (th *TableHandler) Store(c echo.Context) error {
 // @Param Authorization header string true "Bearer Token"
 // @param Header X-Project header string true "Project UUID"
 //
-// @Param table body table_requests.UploadRequest true "Table definition multipart/form-data"
+// @Param table body database.UploadTableRequest true "Table definition multipart/form-data"
 //
-// @Success 201 {object} response.Response{content=resources.TableResponse} "Table created"
+// @Success 201 {object} response.Response{content=database.TableResponse} "Table created"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 422 "Unprocessable entity"
@@ -184,9 +184,9 @@ func (th *TableHandler) Upload(c echo.Context) error {
 // @param Header X-Project header string true "Project UUID"
 //
 // @Param tableUUID path string true "Table UUID"
-// @Param new_name body table_requests.RenameRequest true "Duplicate table name JSON"
+// @Param new_name body database.RenameTableRequest true "Duplicate table name JSON"
 //
-// @Success 201 {object} response.Response{content=resources.TableResponse} "Table duplicated"
+// @Success 201 {object} response.Response{content=database.TableResponse} "Table duplicated"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 422 "Unprocessable entity"
@@ -227,9 +227,9 @@ func (th *TableHandler) Duplicate(c echo.Context) error {
 // @param Header X-Project header string true "Project UUID"
 //
 // @Param tableUUID path string true "Table UUID"
-// @Param new_name body table_requests.RenameRequest true "New table name JSON"
+// @Param new_name body database.RenameTableRequest true "New table name JSON"
 //
-// @Success 200 {object} response.Response{content=resources.TableResponse} "Table renamed"
+// @Success 200 {object} response.Response{content=database.TableResponse} "Table renamed"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 422 "Unprocessable entity"

--- a/internal/api/handlers/table.go
+++ b/internal/api/handlers/table.go
@@ -39,7 +39,7 @@ func NewTableHandler(injector *do.Injector) (*TableHandler, error) {
 // @Failure 500 "Internal server error"
 //
 // @Router /tables [get]
-func (tc *TableHandler) List(c echo.Context) error {
+func (th *TableHandler) List(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -47,7 +47,7 @@ func (tc *TableHandler) List(c echo.Context) error {
 
 	authUser, _ := auth.NewAuth(c).User()
 
-	tables, err := tc.tableService.List(request.ProjectUUID, authUser)
+	tables, err := th.tableService.List(request.ProjectUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -76,7 +76,7 @@ func (tc *TableHandler) List(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /tables/{tableUUID} [get]
-func (tc *TableHandler) Show(c echo.Context) error {
+func (th *TableHandler) Show(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -89,7 +89,7 @@ func (tc *TableHandler) Show(c echo.Context) error {
 		return response.BadRequestResponse(c, "Table name is required")
 	}
 
-	table, err := tc.tableService.GetByName(fullTableName, request.ProjectUUID, authUser)
+	table, err := th.tableService.GetByName(fullTableName, request.ProjectUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -118,7 +118,7 @@ func (tc *TableHandler) Show(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /tables [post]
-func (tc *TableHandler) Store(c echo.Context) error {
+func (th *TableHandler) Store(c echo.Context) error {
 	var request database.CreateTableRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -126,7 +126,7 @@ func (tc *TableHandler) Store(c echo.Context) error {
 
 	authUser, _ := auth.NewAuth(c).User()
 
-	table, err := tc.tableService.Create(database.ToCreateTableInput(request), authUser)
+	table, err := th.tableService.Create(database.ToCreateTableInput(request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -155,7 +155,7 @@ func (tc *TableHandler) Store(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /tables/upload [post]
-func (tc *TableHandler) Upload(c echo.Context) error {
+func (th *TableHandler) Upload(c echo.Context) error {
 	var request database.UploadTableRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -163,7 +163,7 @@ func (tc *TableHandler) Upload(c echo.Context) error {
 
 	authUser, _ := auth.NewAuth(c).User()
 
-	table, err := tc.tableService.Upload(database.ToUploadTableInput(request), authUser)
+	table, err := th.tableService.Upload(database.ToUploadTableInput(request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -193,7 +193,7 @@ func (tc *TableHandler) Upload(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /tables/{tableUUID}/duplicate [put]
-func (tc *TableHandler) Duplicate(c echo.Context) error {
+func (th *TableHandler) Duplicate(c echo.Context) error {
 	var request database.RenameTableRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -206,7 +206,7 @@ func (tc *TableHandler) Duplicate(c echo.Context) error {
 		return response.BadRequestResponse(c, "Table name is required")
 	}
 
-	duplicatedTable, err := tc.tableService.Duplicate(fullTableName, authUser, database.ToRenameTableInput(request))
+	duplicatedTable, err := th.tableService.Duplicate(fullTableName, authUser, database.ToRenameTableInput(request))
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -236,7 +236,7 @@ func (tc *TableHandler) Duplicate(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /tables/{tableUUID}/rename [put]
-func (tc *TableHandler) Rename(c echo.Context) error {
+func (th *TableHandler) Rename(c echo.Context) error {
 	var request database.RenameTableRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -249,7 +249,7 @@ func (tc *TableHandler) Rename(c echo.Context) error {
 		return response.BadRequestResponse(c, "Table name is required")
 	}
 
-	renamedTable, err := tc.tableService.Rename(fullTableName, authUser, database.ToRenameTableInput(request))
+	renamedTable, err := th.tableService.Rename(fullTableName, authUser, database.ToRenameTableInput(request))
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -278,7 +278,7 @@ func (tc *TableHandler) Rename(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /tables/{tableUUID} [delete]
-func (tc *TableHandler) Delete(c echo.Context) error {
+func (th *TableHandler) Delete(c echo.Context) error {
 	var request dto.DefaultRequestWithProjectHeader
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -291,7 +291,7 @@ func (tc *TableHandler) Delete(c echo.Context) error {
 		return response.BadRequestResponse(c, "Table name is required")
 	}
 
-	if _, err := tc.tableService.Delete(fullTableName, request.ProjectUUID, authUser); err != nil {
+	if _, err := th.tableService.Delete(fullTableName, request.ProjectUUID, authUser); err != nil {
 		return response.ErrorResponse(c, err)
 	}
 

--- a/internal/api/handlers/table.go
+++ b/internal/api/handlers/table.go
@@ -33,7 +33,7 @@ func NewTableHandler(injector *do.Injector) (*TableHandler, error) {
 // @Param Authorization header string true "Bearer Token"
 // @param Header X-Project header string true "Project UUID"
 //
-// @Success 200 {object} responses.Response{content=[]resources.TableResponse} "List of tables"
+// @Success 200 {object} response.Response{content=[]resources.TableResponse} "List of tables"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -69,7 +69,7 @@ func (th *TableHandler) List(c echo.Context) error {
 //
 // @Param tableUUID path string true "Table UUID"
 //
-// @Success 200 {object} responses.Response{content=resources.TableResponse} "Table details"
+// @Success 200 {object} response.Response{content=resources.TableResponse} "Table details"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 404 "Table not found"
@@ -111,7 +111,7 @@ func (th *TableHandler) Show(c echo.Context) error {
 //
 // @Param table body table_requests.CreateRequest true "Table definition JSON"
 //
-// @Success 201 {object} responses.Response{content=resources.TableResponse} "Table created"
+// @Success 201 {object} response.Response{content=resources.TableResponse} "Table created"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 422 "Unprocessable entity"
@@ -148,7 +148,7 @@ func (th *TableHandler) Store(c echo.Context) error {
 //
 // @Param table body table_requests.UploadRequest true "Table definition multipart/form-data"
 //
-// @Success 201 {object} responses.Response{content=resources.TableResponse} "Table created"
+// @Success 201 {object} response.Response{content=resources.TableResponse} "Table created"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 422 "Unprocessable entity"
@@ -186,7 +186,7 @@ func (th *TableHandler) Upload(c echo.Context) error {
 // @Param tableUUID path string true "Table UUID"
 // @Param new_name body table_requests.RenameRequest true "Duplicate table name JSON"
 //
-// @Success 201 {object} responses.Response{content=resources.TableResponse} "Table duplicated"
+// @Success 201 {object} response.Response{content=resources.TableResponse} "Table duplicated"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 422 "Unprocessable entity"
@@ -229,7 +229,7 @@ func (th *TableHandler) Duplicate(c echo.Context) error {
 // @Param tableUUID path string true "Table UUID"
 // @Param new_name body table_requests.RenameRequest true "New table name JSON"
 //
-// @Success 200 {object} responses.Response{content=resources.TableResponse} "Table renamed"
+// @Success 200 {object} response.Response{content=resources.TableResponse} "Table renamed"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 422 "Unprocessable entity"

--- a/internal/api/handlers/user.go
+++ b/internal/api/handlers/user.go
@@ -33,7 +33,7 @@ func NewUserHandler(injector *do.Injector) (*UserHandler, error) {
 // @Param Authorization header string true "Bearer Token"
 // @Param id path string true "User UUID"
 //
-// @Success 200 {object} response.Response{content=resources.UserResponse} "User details"
+// @Success 200 {object} response.Response{content=user.Response} "User details"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -69,7 +69,7 @@ func (uh *UserHandler) Show(c echo.Context) error {
 //
 // @Param user body user.LoginRequest true "Login request"
 //
-// @Success 200 {object} response.Response{content=resources.UserResponse} "User details"
+// @Success 200 {object} response.Response{content=user.Response} "User details"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -107,7 +107,7 @@ func (uh *UserHandler) Login(c echo.Context) error {
 //
 // @Param user body user.CreateRequest true "User details"
 //
-// @Success 201 {object} response.Response{content=resources.UserResponse} "User created"
+// @Success 201 {object} response.Response{content=user.Response} "User created"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 500 "Internal server error"
@@ -147,7 +147,7 @@ func (uh *UserHandler) Store(c echo.Context) error {
 // @Param userUUID path string true "User UUID"
 // @Param user body user.UpdateRequest true "User details"
 //
-// @Success 200 {object} response.Response{content=resources.UserResponse} "User updated"
+// @Success 200 {object} response.Response{content=user.Response} "User updated"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"

--- a/internal/api/handlers/user.go
+++ b/internal/api/handlers/user.go
@@ -33,7 +33,7 @@ func NewUserHandler(injector *do.Injector) (*UserHandler, error) {
 // @Param Authorization header string true "Bearer Token"
 // @Param id path string true "User UUID"
 //
-// @Success 200 {object} responses.Response{content=resources.UserResponse} "User details"
+// @Success 200 {object} response.Response{content=resources.UserResponse} "User details"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -69,7 +69,7 @@ func (uh *UserHandler) Show(c echo.Context) error {
 //
 // @Param user body user.LoginRequest true "Login request"
 //
-// @Success 200 {object} responses.Response{content=resources.UserResponse} "User details"
+// @Success 200 {object} response.Response{content=resources.UserResponse} "User details"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"
@@ -107,7 +107,7 @@ func (uh *UserHandler) Login(c echo.Context) error {
 //
 // @Param user body user.CreateRequest true "User details"
 //
-// @Success 201 {object} responses.Response{content=resources.UserResponse} "User created"
+// @Success 201 {object} response.Response{content=resources.UserResponse} "User created"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 500 "Internal server error"
@@ -147,7 +147,7 @@ func (uh *UserHandler) Store(c echo.Context) error {
 // @Param userUUID path string true "User UUID"
 // @Param user body user.UpdateRequest true "User details"
 //
-// @Success 200 {object} responses.Response{content=resources.UserResponse} "User updated"
+// @Success 200 {object} response.Response{content=resources.UserResponse} "User updated"
 // @Failure 422 "Unprocessable entity"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
@@ -189,7 +189,7 @@ func (uh *UserHandler) Update(c echo.Context) error {
 //
 // @Param Authorization header string true "Bearer Token"
 //
-// @Success 200 {object} responses.Response{} "User logged out"
+// @Success 200 {object} response.Response{} "User logged out"
 // @Failure 400 "Invalid input"
 // @Failure 401 "Unauthorized"
 // @Failure 500 "Internal server error"

--- a/internal/api/handlers/user.go
+++ b/internal/api/handlers/user.go
@@ -39,7 +39,7 @@ func NewUserHandler(injector *do.Injector) (*UserHandler, error) {
 // @Failure 500 "Internal server error"
 //
 // @Router /users/{userUUID} [get]
-func (uc *UserHandler) Show(c echo.Context) error {
+func (uh *UserHandler) Show(c echo.Context) error {
 	var request dto.DefaultRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
@@ -50,7 +50,7 @@ func (uc *UserHandler) Show(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	user, err := uc.userService.GetByID(id)
+	user, err := uh.userService.GetByID(id)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -75,7 +75,7 @@ func (uc *UserHandler) Show(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /users/login [post]
-func (uc *UserHandler) Login(c echo.Context) error {
+func (uh *UserHandler) Login(c echo.Context) error {
 	var request userDto.LoginRequest
 	if err := c.Bind(&request); err != nil {
 		return response.BadRequestResponse(c, "user.error.invalidPayload")
@@ -85,7 +85,7 @@ func (uc *UserHandler) Login(c echo.Context) error {
 		return response.UnprocessableResponse(c, err)
 	}
 
-	user, token, err := uc.userService.Login(userDto.ToLoginUserInput(&request))
+	user, token, err := uh.userService.Login(userDto.ToLoginUserInput(&request))
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -113,7 +113,7 @@ func (uc *UserHandler) Login(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /users [post]
-func (uc *UserHandler) Store(c echo.Context) error {
+func (uh *UserHandler) Store(c echo.Context) error {
 	var request userDto.CreateRequest
 	if err := c.Bind(&request); err != nil {
 		return response.BadRequestResponse(c, "user.error.invalidPayload")
@@ -123,7 +123,7 @@ func (uc *UserHandler) Store(c echo.Context) error {
 		return response.UnprocessableResponse(c, err)
 	}
 
-	user, token, err := uc.userService.Create(c, userDto.ToCreateUserInput(&request))
+	user, token, err := uh.userService.Create(c, userDto.ToCreateUserInput(&request))
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -154,7 +154,7 @@ func (uc *UserHandler) Store(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /users/{userUUID} [put]
-func (uc *UserHandler) Update(c echo.Context) error {
+func (uh *UserHandler) Update(c echo.Context) error {
 	authUserUUID, err := auth.NewAuth(c).Uuid()
 	if err != nil {
 		return response.UnauthorizedResponse(c, err.Error())
@@ -170,7 +170,7 @@ func (uc *UserHandler) Update(c echo.Context) error {
 		return response.BadRequestResponse(c, "user.error.invalidPayload")
 	}
 
-	updatedUser, err := uc.userService.Update(userUUID, authUserUUID, userDto.ToUpdateUserInput(&request))
+	updatedUser, err := uh.userService.Update(userUUID, authUserUUID, userDto.ToUpdateUserInput(&request))
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
@@ -195,13 +195,13 @@ func (uc *UserHandler) Update(c echo.Context) error {
 // @Failure 500 "Internal server error"
 //
 // @Router /users/logout [post]
-func (uc *UserHandler) Logout(c echo.Context) error {
+func (uh *UserHandler) Logout(c echo.Context) error {
 	userUUID, err := auth.NewAuth(c).Uuid()
 	if err != nil {
 		return response.UnauthorizedResponse(c, err.Error())
 	}
 
-	err = uc.userService.Logout(userUUID)
+	err = uh.userService.Logout(userUUID)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}

--- a/internal/api/mapper/form/form.go
+++ b/internal/api/mapper/form/form.go
@@ -27,8 +27,8 @@ func ToFormResourceCollection(forms []formDomain.Form) []formDto.Response {
 	return resourceForms
 }
 
-func ToFieldResource(formField *formDomain.Field) formDto.FieldResponse {
-	return formDto.FieldResponse{
+func ToFieldResource(formField *formDomain.Field) formDto.FieldResponseApi {
+	return formDto.FieldResponseApi{
 		Uuid:         formField.Uuid,
 		FormUuid:     formField.FormUuid,
 		Label:        formField.Label,
@@ -50,8 +50,8 @@ func ToFieldResource(formField *formDomain.Field) formDto.FieldResponse {
 	}
 }
 
-func ToFieldResourceCollection(formFields []formDomain.Field) []formDto.FieldResponse {
-	resourceFormFields := make([]formDto.FieldResponse, len(formFields))
+func ToFieldResourceCollection(formFields []formDomain.Field) []formDto.FieldResponseApi {
+	resourceFormFields := make([]formDto.FieldResponseApi, len(formFields))
 	for i, formField := range formFields {
 		resourceFormFields[i] = ToFieldResource(&formField)
 	}

--- a/internal/api/mapper/logging/log.go
+++ b/internal/api/mapper/logging/log.go
@@ -1,0 +1,30 @@
+package logging
+
+import (
+	logDto "fluxton/internal/api/dto/logging"
+	logDomain "fluxton/internal/domain/logging"
+)
+
+func ToResource(log *logDomain.RequestLog) logDto.Response {
+	return logDto.Response{
+		Uuid:      log.Uuid,
+		UserUuid:  log.UserUuid,
+		Method:    log.Method,
+		Status:    log.Status,
+		Endpoint:  log.Endpoint,
+		IPAddress: log.IPAddress,
+		UserAgent: log.UserAgent,
+		Params:    log.Params,
+		Body:      log.Body,
+		CreatedAt: log.CreatedAt.Format("2006-01-02 15:04:05"),
+	}
+}
+
+func ToResourceCollection(files []logDomain.RequestLog) []logDto.Response {
+	resourceContainers := make([]logDto.Response, len(files))
+	for i, currentFile := range files {
+		resourceContainers[i] = ToResource(&currentFile)
+	}
+
+	return resourceContainers
+}

--- a/internal/api/routes/admin.go
+++ b/internal/api/routes/admin.go
@@ -7,16 +7,20 @@ import (
 )
 
 func RegisterAdminRoutes(e *echo.Echo, container *do.Injector, authMiddleware echo.MiddlewareFunc) {
-	settingController := do.MustInvoke[*handlers.SettingHandler](container)
-	healthController := do.MustInvoke[*handlers.HealthHandler](container)
+	settingHandler := do.MustInvoke[*handlers.SettingHandler](container)
+	healthHandler := do.MustInvoke[*handlers.HealthHandler](container)
+	logHandler := do.MustInvoke[*handlers.LogHandler](container)
 
 	adminGroup := e.Group("api/admin", authMiddleware)
 
 	// settings
-	adminGroup.GET("/settings", settingController.List)
-	adminGroup.PUT("/settings", settingController.Update)
-	adminGroup.PUT("/settings/reset", settingController.Reset)
+	adminGroup.GET("/settings", settingHandler.List)
+	adminGroup.PUT("/settings", settingHandler.Update)
+	adminGroup.PUT("/settings/reset", settingHandler.Reset)
 
 	// Health check
-	adminGroup.GET("/health", healthController.Pulse)
+	adminGroup.GET("/health", healthHandler.Pulse)
+
+	// Logs
+	adminGroup.GET("/logs", logHandler.List)
 }

--- a/internal/app/container.go
+++ b/internal/app/container.go
@@ -13,6 +13,7 @@ import (
 	databaseDomain "fluxton/internal/domain/database"
 	"fluxton/internal/domain/form"
 	"fluxton/internal/domain/health"
+	"fluxton/internal/domain/logging"
 	"fluxton/internal/domain/organization"
 	"fluxton/internal/domain/project"
 	"fluxton/internal/domain/setting"
@@ -34,6 +35,8 @@ func InitializeContainer() *do.Injector {
 	})
 
 	// --- Logging ---
+	do.Provide(injector, handlers.NewLogHandler)
+	do.Provide(injector, logging.NewLogService)
 	do.Provide(injector, repositories.NewRequestLogRepository)
 	do.Provide(injector, client.NewDatabaseRepository)
 

--- a/internal/database/repositories/column.go
+++ b/internal/database/repositories/column.go
@@ -11,7 +11,7 @@ type ColumnRepository struct {
 	connection *sqlx.DB
 }
 
-func NewColumnRepository(connection *sqlx.DB) (*ColumnRepository, error) {
+func NewColumnRepository(connection *sqlx.DB) (database.ColumnRepository, error) {
 	return &ColumnRepository{connection: connection}, nil
 }
 

--- a/internal/database/repositories/table.go
+++ b/internal/database/repositories/table.go
@@ -13,7 +13,7 @@ import (
 
 type TableRepository struct {
 	connection       *sqlx.DB
-	columnRepository *ColumnRepository
+	columnRepository database.ColumnRepository
 }
 
 func NewTableRepository(connection *sqlx.DB) (database.TableRepository, error) {

--- a/internal/domain/database/column_repository.go
+++ b/internal/domain/database/column_repository.go
@@ -11,7 +11,6 @@ type ColumnRepository interface {
 	AlterMany(tableName string, fields []Column) error
 	Rename(tableName, oldColumnName, newColumnName string) error
 	Drop(tableName, columnName string) error
-	mapColumnsToNames(columns []Column) []string
 	BuildColumnDefinition(column Column) string
 	BuildForeignKeyConstraint(tableName string, column Column) (string, bool)
 }

--- a/internal/domain/database/column_service.go
+++ b/internal/domain/database/column_service.go
@@ -258,7 +258,7 @@ func (s *ColumnServiceImpl) getClientColumnRepo(dbName string, connection *sqlx.
 	if !ok {
 		connection.Close()
 
-		return nil, nil, errors.NewUnprocessableError("clientTableRepo is invalid")
+		return nil, nil, errors.NewUnprocessableError("clientColumnRepo is invalid")
 	}
 
 	return clientRepo, connection, nil

--- a/internal/domain/logging/service.go
+++ b/internal/domain/logging/service.go
@@ -1,0 +1,36 @@
+package logging
+
+import (
+	"fluxton/internal/domain/admin"
+	"fluxton/internal/domain/auth"
+	"fluxton/internal/domain/shared"
+	"fluxton/pkg/errors"
+	"github.com/samber/do"
+)
+
+type Service interface {
+	List(paginationParams shared.PaginationParams, authUser auth.User) ([]RequestLog, error)
+}
+
+type ServiceImpl struct {
+	adminPolicy *admin.Policy
+	logRepo     Repository
+}
+
+func NewFileService(injector *do.Injector) (Service, error) {
+	policy := do.MustInvoke[*admin.Policy](injector)
+	logRepo := do.MustInvoke[Repository](injector)
+
+	return &ServiceImpl{
+		adminPolicy: policy,
+		logRepo:     logRepo,
+	}, nil
+}
+
+func (s *ServiceImpl) List(paginationParams shared.PaginationParams, authUser auth.User) ([]RequestLog, error) {
+	if !s.adminPolicy.CanAccess(authUser) {
+		return []RequestLog{}, errors.NewForbiddenError("log.error.listForbidden")
+	}
+
+	return s.logRepo.List(paginationParams)
+}

--- a/internal/domain/logging/service.go
+++ b/internal/domain/logging/service.go
@@ -17,8 +17,8 @@ type ServiceImpl struct {
 	logRepo     Repository
 }
 
-func NewFileService(injector *do.Injector) (Service, error) {
-	policy := do.MustInvoke[*admin.Policy](injector)
+func NewLogService(injector *do.Injector) (Service, error) {
+	policy := admin.NewAdminPolicy()
 	logRepo := do.MustInvoke[Repository](injector)
 
 	return &ServiceImpl{

--- a/internal/domain/setting/service.go
+++ b/internal/domain/setting/service.go
@@ -10,8 +10,6 @@ import (
 	"time"
 )
 
-const settingsCacheKey = "settings"
-
 type Service interface {
 	List() ([]Setting, error)
 	Get(name string) Setting

--- a/pkg/message/message.go
+++ b/pkg/message/message.go
@@ -138,6 +138,7 @@ var messages = map[string]string{
 	// Others
 	"database_stats.error.forbidden": "You don't have permission to view database stats",
 	"function.error.listForbidden":   "You don't have permission to view functions",
+	"log.error.listForbidden":        "You don't have permission to view logs",
 }
 
 func Message(key string) string {


### PR DESCRIPTION
All incoming requests are logged in Fluxton. Admin should be able to view logs history and filter out requests based on core parameters like `endpoint`, `method` and more. This pull request makes it possible.

**What changes**
- Add `api/admin/logs` endpoint
- Supported query parameters: `page`, `limit`, `sort`, `order`, `method`, `status`, `endpoint`, `ipAddress` and `userUuid`
- Update swagger docs and fix issues after refactoring