### PR TITLE
[FLX-56] Cleaner response mappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,4 +43,4 @@ pgr.destroy: ## Destroy all postgrest containers
 	@docker rm -f $(shell docker ps -a -q --filter "name=postgrest_")
 
 docs.generate: ## Generate docs
-	swag init --dir . --output docs
+	swag init --dir cmd,internal --output docs

--- a/internal/api/handlers/backup.go
+++ b/internal/api/handlers/backup.go
@@ -2,20 +2,20 @@ package handlers
 
 import (
 	"fluxton/internal/api/dto"
-	backupMapper "fluxton/internal/api/mapper/backup"
+	"fluxton/internal/api/mapper"
 	"fluxton/internal/api/response"
-	backupDomain "fluxton/internal/domain/backup"
+	"fluxton/internal/domain/backup"
 	"fluxton/pkg/auth"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/do"
 )
 
 type BackupHandler struct {
-	backupService backupDomain.Service
+	backupService backup.Service
 }
 
 func NewBackupHandler(injector *do.Injector) (*BackupHandler, error) {
-	backupService := do.MustInvoke[backupDomain.Service](injector)
+	backupService := do.MustInvoke[backup.Service](injector)
 
 	return &BackupHandler{backupService: backupService}, nil
 }
@@ -49,7 +49,7 @@ func (bh *BackupHandler) List(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, backupMapper.ToResourceCollection(backups))
+	return response.SuccessResponse(c, mapper.ToBackupResourceCollection(backups))
 }
 
 // Show retrieves details of a specific backup
@@ -85,12 +85,12 @@ func (bh *BackupHandler) Show(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	backup, err := bh.backupService.GetByUUID(backupUUID, authUser)
+	fetchedBackup, err := bh.backupService.GetByUUID(backupUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, backupMapper.ToResource(&backup))
+	return response.SuccessResponse(c, mapper.ToBackupResource(&fetchedBackup))
 }
 
 // Store creates a new backup
@@ -122,12 +122,12 @@ func (bh *BackupHandler) Store(c echo.Context) error {
 
 	authUser, _ := auth.NewAuth(c).User()
 
-	backup, err := bh.backupService.Create(request.ProjectUUID, authUser)
+	storedBackup, err := bh.backupService.Create(request.ProjectUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.CreatedResponse(c, backupMapper.ToResource(&backup))
+	return response.CreatedResponse(c, mapper.ToBackupResource(&storedBackup))
 }
 
 // Delete removes a backup

--- a/internal/api/handlers/column.go
+++ b/internal/api/handlers/column.go
@@ -2,10 +2,10 @@ package handlers
 
 import (
 	"fluxton/internal/api/dto"
-	"fluxton/internal/api/dto/database"
-	databaseMapper "fluxton/internal/api/mapper/database"
+	databaseDto "fluxton/internal/api/dto/database"
+	"fluxton/internal/api/mapper"
 	"fluxton/internal/api/response"
-	databaseDomain "fluxton/internal/domain/database"
+	"fluxton/internal/domain/database"
 	"fluxton/pkg/auth"
 	"fluxton/pkg/errors"
 	"github.com/labstack/echo/v4"
@@ -13,11 +13,11 @@ import (
 )
 
 type ColumnHandler struct {
-	columnService databaseDomain.ColumnService
+	columnService database.ColumnService
 }
 
 func NewColumnHandler(injector *do.Injector) (*ColumnHandler, error) {
-	columnService := do.MustInvoke[databaseDomain.ColumnService](injector)
+	columnService := do.MustInvoke[database.ColumnService](injector)
 
 	return &ColumnHandler{columnService: columnService}, nil
 }
@@ -58,7 +58,7 @@ func (ch *ColumnHandler) List(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, databaseMapper.ToColumnResourceCollection(columns))
+	return response.SuccessResponse(c, mapper.ToColumnResourceCollection(columns))
 }
 
 // Store adds new columns to a table.
@@ -84,7 +84,7 @@ func (ch *ColumnHandler) List(c echo.Context) error {
 //
 // @Router /tables/{fullTableName}/columns [post]
 func (ch *ColumnHandler) Store(c echo.Context) error {
-	var request database.CreateColumnRequest
+	var request databaseDto.CreateColumnRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
@@ -96,12 +96,12 @@ func (ch *ColumnHandler) Store(c echo.Context) error {
 		return response.BadRequestResponse(c, "Table name is required")
 	}
 
-	columns, err := ch.columnService.CreateMany(fullTableName, database.ToCreateColumnInput(request), authUser)
+	columns, err := ch.columnService.CreateMany(fullTableName, databaseDto.ToCreateColumnInput(request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.CreatedResponse(c, databaseMapper.ToColumnResourceCollection(columns))
+	return response.CreatedResponse(c, mapper.ToColumnResourceCollection(columns))
 }
 
 // Alter modifies column types in a table.
@@ -127,7 +127,7 @@ func (ch *ColumnHandler) Store(c echo.Context) error {
 //
 // @Router /tables/{fullTableName}/columns [put]
 func (ch *ColumnHandler) Alter(c echo.Context) error {
-	var request database.CreateColumnRequest
+	var request databaseDto.CreateColumnRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
@@ -139,12 +139,12 @@ func (ch *ColumnHandler) Alter(c echo.Context) error {
 		return response.BadRequestResponse(c, "Table name is required")
 	}
 
-	columns, err := ch.columnService.AlterMany(fullTableName, database.ToCreateColumnInput(request), authUser)
+	columns, err := ch.columnService.AlterMany(fullTableName, databaseDto.ToCreateColumnInput(request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, databaseMapper.ToColumnResourceCollection(columns))
+	return response.SuccessResponse(c, mapper.ToColumnResourceCollection(columns))
 }
 
 // Rename updates the name of an existing column.
@@ -171,7 +171,7 @@ func (ch *ColumnHandler) Alter(c echo.Context) error {
 //
 // @Router /tables/{fullTableName}/columns/{columnName} [put]
 func (ch *ColumnHandler) Rename(c echo.Context) error {
-	var request database.RenameColumnRequest
+	var request databaseDto.RenameColumnRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
@@ -183,12 +183,12 @@ func (ch *ColumnHandler) Rename(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	columns, err := ch.columnService.Rename(columnName, fullTableName, database.ToRenameColumnInput(request), authUser)
+	columns, err := ch.columnService.Rename(columnName, fullTableName, databaseDto.ToRenameColumnInput(request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, databaseMapper.ToColumnResourceCollection(columns))
+	return response.SuccessResponse(c, mapper.ToColumnResourceCollection(columns))
 }
 
 // Delete removes a column from a table.

--- a/internal/api/handlers/container.go
+++ b/internal/api/handlers/container.go
@@ -2,21 +2,21 @@ package handlers
 
 import (
 	"fluxton/internal/api/dto"
-	"fluxton/internal/api/dto/storage/container"
-	containerMapper "fluxton/internal/api/mapper/container"
+	containerDto "fluxton/internal/api/dto/storage/container"
+	"fluxton/internal/api/mapper"
 	"fluxton/internal/api/response"
-	containerDomain "fluxton/internal/domain/storage/container"
+	"fluxton/internal/domain/storage/container"
 	"fluxton/pkg/auth"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/do"
 )
 
 type ContainerHandler struct {
-	containerService containerDomain.Service
+	containerService container.Service
 }
 
 func NewContainerHandler(injector *do.Injector) (*ContainerHandler, error) {
-	containerService := do.MustInvoke[containerDomain.Service](injector)
+	containerService := do.MustInvoke[container.Service](injector)
 
 	return &ContainerHandler{containerService: containerService}, nil
 }
@@ -58,7 +58,7 @@ func (ch *ContainerHandler) List(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, containerMapper.ToResourceCollection(containers))
+	return response.SuccessResponse(c, mapper.ToContainerResourceCollection(containers))
 }
 
 // Show retrieves details of a specific container.
@@ -97,7 +97,7 @@ func (ch *ContainerHandler) Show(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, containerMapper.ToResource(&fetchedContainer))
+	return response.SuccessResponse(c, mapper.ToContainerResource(&fetchedContainer))
 }
 
 // Store creates a new container
@@ -121,19 +121,19 @@ func (ch *ContainerHandler) Show(c echo.Context) error {
 //
 // @Router /storage [post]
 func (ch *ContainerHandler) Store(c echo.Context) error {
-	var request container.CreateRequest
+	var request containerDto.CreateRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
 
 	authUser, _ := auth.NewAuth(c).User()
 
-	fetchedContainer, err := ch.containerService.Create(container.ToCreateContainerInput(&request), authUser)
+	fetchedContainer, err := ch.containerService.Create(containerDto.ToCreateContainerInput(&request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.CreatedResponse(c, containerMapper.ToResource(&fetchedContainer))
+	return response.CreatedResponse(c, mapper.ToContainerResource(&fetchedContainer))
 }
 
 // Update a container
@@ -159,7 +159,7 @@ func (ch *ContainerHandler) Store(c echo.Context) error {
 //
 // @Router /storage/containers/{containerUUID} [put]
 func (ch *ContainerHandler) Update(c echo.Context) error {
-	var request container.CreateRequest
+	var request containerDto.CreateRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
@@ -171,12 +171,12 @@ func (ch *ContainerHandler) Update(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	updatedContainer, err := ch.containerService.Update(containerUUID, authUser, container.ToCreateContainerInput(&request))
+	updatedContainer, err := ch.containerService.Update(containerUUID, authUser, containerDto.ToCreateContainerInput(&request))
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, containerMapper.ToResource(updatedContainer))
+	return response.SuccessResponse(c, mapper.ToContainerResource(updatedContainer))
 }
 
 // Delete a container

--- a/internal/api/handlers/file.go
+++ b/internal/api/handlers/file.go
@@ -2,21 +2,21 @@ package handlers
 
 import (
 	"fluxton/internal/api/dto"
-	"fluxton/internal/api/dto/storage/file"
-	fileMapper "fluxton/internal/api/mapper/file"
+	fileDto "fluxton/internal/api/dto/storage/file"
+	"fluxton/internal/api/mapper"
 	"fluxton/internal/api/response"
-	fileDomain "fluxton/internal/domain/storage/file"
+	"fluxton/internal/domain/storage/file"
 	"fluxton/pkg/auth"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/do"
 )
 
 type FileHandler struct {
-	fileService fileDomain.Service
+	fileService file.Service
 }
 
 func NewFileHandler(injector *do.Injector) (*FileHandler, error) {
-	fileService := do.MustInvoke[fileDomain.Service](injector)
+	fileService := do.MustInvoke[file.Service](injector)
 
 	return &FileHandler{fileService: fileService}, nil
 }
@@ -63,7 +63,7 @@ func (fh *FileHandler) List(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, fileMapper.ToResourceCollection(files))
+	return response.SuccessResponse(c, mapper.ToFileResourceCollection(files))
 }
 
 // Show retrieves details of a specific file.
@@ -108,7 +108,7 @@ func (fh *FileHandler) Show(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, fileMapper.ToResource(&fetchedFile))
+	return response.SuccessResponse(c, mapper.ToFileResource(&fetchedFile))
 }
 
 // Store creates a new file in a container
@@ -131,7 +131,7 @@ func (fh *FileHandler) Show(c echo.Context) error {
 //
 // @Router /containers/{containerUUID}/files [post]
 func (fh *FileHandler) Store(c echo.Context) error {
-	var request file.CreateRequest
+	var request fileDto.CreateRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
@@ -143,12 +143,12 @@ func (fh *FileHandler) Store(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	createdFile, err := fh.fileService.Create(containerUUID, file.ToCreateFileInput(&request), authUser)
+	createdFile, err := fh.fileService.Create(containerUUID, fileDto.ToCreateFileInput(&request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.CreatedResponse(c, fileMapper.ToResource(&createdFile))
+	return response.CreatedResponse(c, mapper.ToFileResource(&createdFile))
 }
 
 // Rename updates the name of a file
@@ -172,7 +172,7 @@ func (fh *FileHandler) Store(c echo.Context) error {
 //
 // @Router /containers/{containerUUID}/files/{fileUUID}/rename [put]
 func (fh *FileHandler) Rename(c echo.Context) error {
-	var request file.RenameRequest
+	var request fileDto.RenameRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
@@ -189,12 +189,12 @@ func (fh *FileHandler) Rename(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	updatedFile, err := fh.fileService.Rename(fileUUID, containerUUID, authUser, file.ToRenameFileInput(&request))
+	updatedFile, err := fh.fileService.Rename(fileUUID, containerUUID, authUser, fileDto.ToRenameFileInput(&request))
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, fileMapper.ToResource(updatedFile))
+	return response.SuccessResponse(c, mapper.ToFileResource(updatedFile))
 }
 
 // Delete removes a file from a container

--- a/internal/api/handlers/form.go
+++ b/internal/api/handlers/form.go
@@ -2,21 +2,21 @@ package handlers
 
 import (
 	"fluxton/internal/api/dto"
-	"fluxton/internal/api/dto/form"
-	formMapper "fluxton/internal/api/mapper/form"
+	formDto "fluxton/internal/api/dto/form"
+	"fluxton/internal/api/mapper"
 	"fluxton/internal/api/response"
-	formDomain "fluxton/internal/domain/form"
+	"fluxton/internal/domain/form"
 	"fluxton/pkg/auth"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/do"
 )
 
 type FormHandler struct {
-	formService formDomain.Service
+	formService form.Service
 }
 
 func NewFormHandler(injector *do.Injector) (*FormHandler, error) {
-	formService := do.MustInvoke[formDomain.Service](injector)
+	formService := do.MustInvoke[form.Service](injector)
 
 	return &FormHandler{formService: formService}, nil
 }
@@ -57,7 +57,7 @@ func (fh *FormHandler) List(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, formMapper.ToFormResourceCollection(forms))
+	return response.SuccessResponse(c, mapper.ToFormResourceCollection(forms))
 }
 
 // Show retrieves details of a specific form
@@ -98,7 +98,7 @@ func (fh *FormHandler) Show(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, formMapper.ToFormResource(&fetchedForm))
+	return response.SuccessResponse(c, mapper.ToFormResource(&fetchedForm))
 }
 
 // Store creates a new form
@@ -123,19 +123,19 @@ func (fh *FormHandler) Show(c echo.Context) error {
 //
 // @Router /forms [post]
 func (fh *FormHandler) Store(c echo.Context) error {
-	var request form.CreateRequest
+	var request formDto.CreateRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
 
 	authUser, _ := auth.NewAuth(c).User()
 
-	createdForm, err := fh.formService.Create(form.ToCreateFormInput(&request), authUser)
+	createdForm, err := fh.formService.Create(formDto.ToCreateFormInput(&request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.CreatedResponse(c, formMapper.ToFormResource(&createdForm))
+	return response.CreatedResponse(c, mapper.ToFormResource(&createdForm))
 }
 
 // Update updates an existing form
@@ -161,7 +161,7 @@ func (fh *FormHandler) Store(c echo.Context) error {
 //
 // @Router /forms/{formUUID} [put]
 func (fh *FormHandler) Update(c echo.Context) error {
-	var request form.CreateRequest
+	var request formDto.CreateRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
@@ -173,12 +173,12 @@ func (fh *FormHandler) Update(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	updatedForm, err := fh.formService.Update(formUUID, authUser, form.ToCreateFormInput(&request))
+	updatedForm, err := fh.formService.Update(formUUID, authUser, formDto.ToCreateFormInput(&request))
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, formMapper.ToFormResource(updatedForm))
+	return response.SuccessResponse(c, mapper.ToFormResource(updatedForm))
 }
 
 // Delete removes a form

--- a/internal/api/handlers/form_field.go
+++ b/internal/api/handlers/form_field.go
@@ -2,21 +2,21 @@ package handlers
 
 import (
 	"fluxton/internal/api/dto"
-	"fluxton/internal/api/dto/form"
-	formMapper "fluxton/internal/api/mapper/form"
+	formDto "fluxton/internal/api/dto/form"
+	"fluxton/internal/api/mapper"
 	"fluxton/internal/api/response"
-	formDomain "fluxton/internal/domain/form"
+	"fluxton/internal/domain/form"
 	"fluxton/pkg/auth"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/do"
 )
 
 type FormFieldHandler struct {
-	formFieldService formDomain.FieldService
+	formFieldService form.FieldService
 }
 
 func NewFormFieldHandler(injector *do.Injector) (*FormFieldHandler, error) {
-	formFieldService := do.MustInvoke[formDomain.FieldService](injector)
+	formFieldService := do.MustInvoke[form.FieldService](injector)
 
 	return &FormFieldHandler{formFieldService: formFieldService}, nil
 }
@@ -57,7 +57,7 @@ func (ffh *FormFieldHandler) List(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, formMapper.ToFieldResourceCollection(formFields))
+	return response.SuccessResponse(c, mapper.ToFieldResourceCollection(formFields))
 }
 
 // Show retrieves details of a specific field
@@ -97,7 +97,7 @@ func (ffh *FormFieldHandler) Show(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, formMapper.ToFieldResource(&formField))
+	return response.SuccessResponse(c, mapper.ToFieldResource(&formField))
 }
 
 // Store creates a new field for a form
@@ -121,7 +121,7 @@ func (ffh *FormFieldHandler) Show(c echo.Context) error {
 //
 // @Router /forms/{formUUID}/fields [post]
 func (ffh *FormFieldHandler) Store(c echo.Context) error {
-	var request form.CreateFormFieldsRequest
+	var request formDto.CreateFormFieldsRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
@@ -133,12 +133,12 @@ func (ffh *FormFieldHandler) Store(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	formFields, err := ffh.formFieldService.CreateMany(formUUID, form.ToCreateFormFieldInput(&request), authUser)
+	formFields, err := ffh.formFieldService.CreateMany(formUUID, formDto.ToCreateFormFieldInput(&request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.CreatedResponse(c, formMapper.ToFieldResourceCollection(formFields))
+	return response.CreatedResponse(c, mapper.ToFieldResourceCollection(formFields))
 }
 
 // Update updates an existing field
@@ -163,7 +163,7 @@ func (ffh *FormFieldHandler) Store(c echo.Context) error {
 //
 // @Router /forms/{formUUID}/fields/{fieldUUID} [put]
 func (ffh *FormFieldHandler) Update(c echo.Context) error {
-	var request form.UpdateFormFieldRequest
+	var request formDto.UpdateFormFieldRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
@@ -180,12 +180,12 @@ func (ffh *FormFieldHandler) Update(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	updatedFormField, err := ffh.formFieldService.Update(formUUID, fieldUUID, authUser, form.ToUpdateFormFieldInput(&request))
+	updatedFormField, err := ffh.formFieldService.Update(formUUID, fieldUUID, authUser, formDto.ToUpdateFormFieldInput(&request))
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, formMapper.ToFieldResource(updatedFormField))
+	return response.SuccessResponse(c, mapper.ToFieldResource(updatedFormField))
 }
 
 // Delete deletes a field from a form

--- a/internal/api/handlers/form_response.go
+++ b/internal/api/handlers/form_response.go
@@ -2,10 +2,10 @@ package handlers
 
 import (
 	"fluxton/internal/api/dto"
-	"fluxton/internal/api/dto/form"
-	formMapper "fluxton/internal/api/mapper/form"
+	formDto "fluxton/internal/api/dto/form"
+	"fluxton/internal/api/mapper"
 	"fluxton/internal/api/response"
-	formDomain "fluxton/internal/domain/form"
+	"fluxton/internal/domain/form"
 	"fluxton/pkg/auth"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
@@ -13,11 +13,11 @@ import (
 )
 
 type FormResponseHandler struct {
-	formResponseService formDomain.FieldResponseService
+	formResponseService form.FieldResponseService
 }
 
 func NewFormResponseHandler(injector *do.Injector) (*FormResponseHandler, error) {
-	formResponseService := do.MustInvoke[formDomain.FieldResponseService](injector)
+	formResponseService := do.MustInvoke[form.FieldResponseService](injector)
 
 	return &FormResponseHandler{formResponseService: formResponseService}, nil
 }
@@ -59,7 +59,7 @@ func (ffh *FormResponseHandler) List(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, formMapper.ToResponseResourceCollection(formResponses))
+	return response.SuccessResponse(c, mapper.ToResponseResourceCollection(formResponses))
 }
 
 // Show details of a single form response
@@ -101,7 +101,7 @@ func (ffh *FormResponseHandler) Show(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, formMapper.ToResponseResource(formResponse))
+	return response.SuccessResponse(c, mapper.ToResponseResource(formResponse))
 }
 
 // Store a new form response
@@ -127,7 +127,7 @@ func (ffh *FormResponseHandler) Show(c echo.Context) error {
 //
 // @Router /forms/{formUUID}/responses [post]
 func (ffh *FormResponseHandler) Store(c echo.Context) error {
-	var request form.CreateResponseRequest
+	var request formDto.CreateResponseRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
@@ -139,12 +139,12 @@ func (ffh *FormResponseHandler) Store(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	formResponse, err := ffh.formResponseService.Create(formUUID, form.ToCreateFormResponseInput(&request), authUser)
+	formResponse, err := ffh.formResponseService.Create(formUUID, formDto.ToCreateFormResponseInput(&request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.CreatedResponse(c, formMapper.ToResponseResource(&formResponse))
+	return response.CreatedResponse(c, mapper.ToResponseResource(&formResponse))
 }
 
 // Delete a form response

--- a/internal/api/handlers/function.go
+++ b/internal/api/handlers/function.go
@@ -2,21 +2,21 @@ package handlers
 
 import (
 	"fluxton/internal/api/dto"
-	"fluxton/internal/api/dto/database"
-	databaseMapper "fluxton/internal/api/mapper/database"
+	databaseDto "fluxton/internal/api/dto/database"
+	"fluxton/internal/api/mapper"
 	"fluxton/internal/api/response"
-	functionDomain "fluxton/internal/domain/database"
+	"fluxton/internal/domain/database"
 	"fluxton/pkg/auth"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/do"
 )
 
 type FunctionHandler struct {
-	functionService functionDomain.FunctionService
+	functionService database.FunctionService
 }
 
 func NewFunctionHandler(injector *do.Injector) (*FunctionHandler, error) {
-	functionService := do.MustInvoke[functionDomain.FunctionService](injector)
+	functionService := do.MustInvoke[database.FunctionService](injector)
 
 	return &FunctionHandler{functionService: functionService}, nil
 }
@@ -60,7 +60,7 @@ func (fh *FunctionHandler) List(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, databaseMapper.ToFunctionResourceCollection(functions))
+	return response.SuccessResponse(c, mapper.ToFunctionResourceCollection(functions))
 }
 
 // Show retrieves details of a specific function
@@ -107,7 +107,7 @@ func (fh *FunctionHandler) Show(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, databaseMapper.ToFunctionResource(&fetchedFunction))
+	return response.SuccessResponse(c, mapper.ToFunctionResource(&fetchedFunction))
 }
 
 // Store creates a new function
@@ -132,7 +132,7 @@ func (fh *FunctionHandler) Show(c echo.Context) error {
 //
 // @Router /functions/{schema} [post]
 func (fh *FunctionHandler) Store(c echo.Context) error {
-	var request database.CreateFunctionRequest
+	var request databaseDto.CreateFunctionRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
@@ -144,12 +144,12 @@ func (fh *FunctionHandler) Store(c echo.Context) error {
 		return response.BadRequestResponse(c, "Schema is required")
 	}
 
-	createdFunction, err := fh.functionService.Create(schema, database.ToCreateFunctionInput(request), authUser)
+	createdFunction, err := fh.functionService.Create(schema, databaseDto.ToCreateFunctionInput(request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.CreatedResponse(c, databaseMapper.ToFunctionResource(&createdFunction))
+	return response.CreatedResponse(c, mapper.ToFunctionResource(&createdFunction))
 }
 
 // Delete removes a function

--- a/internal/api/handlers/log.go
+++ b/internal/api/handlers/log.go
@@ -1,21 +1,21 @@
 package handlers
 
 import (
-	"fluxton/internal/api/dto/logging"
-	logMapper "fluxton/internal/api/mapper/logging"
+	loggingDto "fluxton/internal/api/dto/logging"
+	"fluxton/internal/api/mapper"
 	"fluxton/internal/api/response"
-	logDomain "fluxton/internal/domain/logging"
+	"fluxton/internal/domain/logging"
 	"fluxton/pkg/auth"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/do"
 )
 
 type LogHandler struct {
-	logService logDomain.Service
+	logService logging.Service
 }
 
 func NewLogHandler(injector *do.Injector) (*LogHandler, error) {
-	logService := do.MustInvoke[logDomain.Service](injector)
+	logService := do.MustInvoke[logging.Service](injector)
 
 	return &LogHandler{logService: logService}, nil
 }
@@ -43,7 +43,7 @@ func NewLogHandler(injector *do.Injector) (*LogHandler, error) {
 //
 // @Router /admin/logs [get]
 func (lh *LogHandler) List(c echo.Context) error {
-	var request logging.ListRequest
+	var request loggingDto.ListRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
@@ -56,5 +56,5 @@ func (lh *LogHandler) List(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, logMapper.ToResourceCollection(logs))
+	return response.SuccessResponse(c, mapper.ToLoggingResourceCollection(logs))
 }

--- a/internal/api/handlers/organization.go
+++ b/internal/api/handlers/organization.go
@@ -3,20 +3,20 @@ package handlers
 import (
 	"fluxton/internal/api/dto"
 	organizationDto "fluxton/internal/api/dto/organization"
-	organizationMapper "fluxton/internal/api/mapper/organization"
+	"fluxton/internal/api/mapper"
 	"fluxton/internal/api/response"
-	organizationDomain "fluxton/internal/domain/organization"
+	"fluxton/internal/domain/organization"
 	"fluxton/pkg/auth"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/do"
 )
 
 type OrganizationHandler struct {
-	organizationService organizationDomain.Service
+	organizationService organization.Service
 }
 
 func NewOrganizationHandler(injector *do.Injector) (*OrganizationHandler, error) {
-	organizationService := do.MustInvoke[organizationDomain.Service](injector)
+	organizationService := do.MustInvoke[organization.Service](injector)
 
 	return &OrganizationHandler{organizationService: organizationService}, nil
 }
@@ -56,7 +56,7 @@ func (oh *OrganizationHandler) List(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, organizationMapper.ToResourceCollection(organizations))
+	return response.SuccessResponse(c, mapper.ToOrganizationResourceCollection(organizations))
 }
 
 // Show details of a single organization
@@ -91,12 +91,12 @@ func (oh *OrganizationHandler) Show(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	organization, err := oh.organizationService.GetByID(organizationUUID, authUser)
+	fetchedOrganization, err := oh.organizationService.GetByID(organizationUUID, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, organizationMapper.ToResource(&organization))
+	return response.SuccessResponse(c, mapper.ToOrganizationResource(&fetchedOrganization))
 }
 
 // Store creates a new organization
@@ -129,12 +129,12 @@ func (oh *OrganizationHandler) Store(c echo.Context) error {
 		return response.UnauthorizedResponse(c, err.Error())
 	}
 
-	organization, err := oh.organizationService.Create(request.Name, authUser)
+	storedOrganization, err := oh.organizationService.Create(request.Name, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.CreatedResponse(c, organizationMapper.ToResource(&organization))
+	return response.CreatedResponse(c, mapper.ToOrganizationResource(&storedOrganization))
 }
 
 // Update an organization
@@ -175,7 +175,7 @@ func (oh *OrganizationHandler) Update(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, organizationMapper.ToResource(updatedOrganization))
+	return response.SuccessResponse(c, mapper.ToOrganizationResource(updatedOrganization))
 }
 
 // Delete an organization

--- a/internal/api/handlers/organization_member.go
+++ b/internal/api/handlers/organization_member.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"fluxton/internal/api/dto"
 	organizationDto "fluxton/internal/api/dto/organization"
-	userMapper "fluxton/internal/api/mapper/user"
+	userMapper "fluxton/internal/api/mapper"
 	"fluxton/internal/api/response"
 	organizationDomain "fluxton/internal/domain/organization"
 	"fluxton/pkg/auth"
@@ -58,7 +58,7 @@ func (omh *OrganizationMemberHandler) List(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, userMapper.ToResponseCollection(organizationUsers))
+	return response.SuccessResponse(c, userMapper.ToUserResourceCollection(organizationUsers))
 }
 
 // Store creates a user in an organization
@@ -99,7 +99,7 @@ func (omh *OrganizationMemberHandler) Store(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.CreatedResponse(c, userMapper.ToResponse(&organizationUser))
+	return response.CreatedResponse(c, userMapper.ToUserResource(&organizationUser))
 }
 
 // Delete a user from an organization

--- a/internal/api/handlers/project.go
+++ b/internal/api/handlers/project.go
@@ -2,21 +2,21 @@ package handlers
 
 import (
 	"fluxton/internal/api/dto"
-	"fluxton/internal/api/dto/project"
-	projectMapper "fluxton/internal/api/mapper/project"
+	projectDto "fluxton/internal/api/dto/project"
+	"fluxton/internal/api/mapper"
 	"fluxton/internal/api/response"
-	projectDomain "fluxton/internal/domain/project"
+	"fluxton/internal/domain/project"
 	"fluxton/pkg/auth"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/do"
 )
 
 type ProjectHandler struct {
-	projectService projectDomain.Service
+	projectService project.Service
 }
 
 func NewProjectHandler(injector *do.Injector) (*ProjectHandler, error) {
-	projectService := do.MustInvoke[projectDomain.Service](injector)
+	projectService := do.MustInvoke[project.Service](injector)
 
 	return &ProjectHandler{projectService: projectService}, nil
 }
@@ -63,7 +63,7 @@ func (ph *ProjectHandler) List(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, projectMapper.ToResourceCollection(projects))
+	return response.SuccessResponse(c, mapper.ToProjectResourceCollection(projects))
 }
 
 // Show details of a single project
@@ -103,7 +103,7 @@ func (ph *ProjectHandler) Show(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, projectMapper.ToResource(&fetchedProject))
+	return response.SuccessResponse(c, mapper.ToProjectResource(&fetchedProject))
 }
 
 // Store creates a new project
@@ -127,19 +127,19 @@ func (ph *ProjectHandler) Show(c echo.Context) error {
 //
 // @Router /projects [post]
 func (ph *ProjectHandler) Store(c echo.Context) error {
-	var request project.CreateRequest
+	var request projectDto.CreateRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
 
 	authUser, _ := auth.NewAuth(c).User()
 
-	updatedProject, err := ph.projectService.Create(project.ToCreateProjectInput(&request), authUser)
+	updatedProject, err := ph.projectService.Create(projectDto.ToCreateProjectInput(&request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.CreatedResponse(c, projectMapper.ToResource(&updatedProject))
+	return response.CreatedResponse(c, mapper.ToProjectResource(&updatedProject))
 }
 
 // Update a project
@@ -163,7 +163,7 @@ func (ph *ProjectHandler) Store(c echo.Context) error {
 //
 // @Router /projects/{projectUUID} [put]
 func (ph *ProjectHandler) Update(c echo.Context) error {
-	var request project.UpdateRequest
+	var request projectDto.UpdateRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
@@ -175,12 +175,12 @@ func (ph *ProjectHandler) Update(c echo.Context) error {
 		return response.BadRequestResponse(c, err.Error())
 	}
 
-	updatedOrganization, err := ph.projectService.Update(projectUUID, authUser, project.ToUpdateProjectInput(&request))
+	updatedOrganization, err := ph.projectService.Update(projectUUID, authUser, projectDto.ToUpdateProjectInput(&request))
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, projectMapper.ToResource(updatedOrganization))
+	return response.SuccessResponse(c, mapper.ToProjectResource(updatedOrganization))
 }
 
 // Delete a project

--- a/internal/api/handlers/setting.go
+++ b/internal/api/handlers/setting.go
@@ -1,21 +1,21 @@
 package handlers
 
 import (
-	"fluxton/internal/api/dto/setting"
-	settingMapper "fluxton/internal/api/mapper/setting"
+	settingDto "fluxton/internal/api/dto/setting"
+	"fluxton/internal/api/mapper"
 	"fluxton/internal/api/response"
-	settingDomain "fluxton/internal/domain/setting"
+	"fluxton/internal/domain/setting"
 	"fluxton/pkg/auth"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/do"
 )
 
 type SettingHandler struct {
-	settingService settingDomain.Service
+	settingService setting.Service
 }
 
 func NewSettingHandler(injector *do.Injector) (*SettingHandler, error) {
-	settingService := do.MustInvoke[settingDomain.Service](injector)
+	settingService := do.MustInvoke[setting.Service](injector)
 
 	return &SettingHandler{settingService: settingService}, nil
 }
@@ -26,11 +26,11 @@ func (sh *SettingHandler) List(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, settingMapper.ToResourceCollection(settings))
+	return response.SuccessResponse(c, mapper.ToSettingResourceCollection(settings))
 }
 
 func (sh *SettingHandler) Update(c echo.Context) error {
-	var request setting.UpdateRequest
+	var request settingDto.UpdateRequest
 	authUser, _ := auth.NewAuth(c).User()
 
 	if err := request.BindAndValidate(c); err != nil {
@@ -42,7 +42,7 @@ func (sh *SettingHandler) Update(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, settingMapper.ToResourceCollection(updatedSettings))
+	return response.SuccessResponse(c, mapper.ToSettingResourceCollection(updatedSettings))
 }
 
 func (sh *SettingHandler) Reset(c echo.Context) error {
@@ -53,5 +53,5 @@ func (sh *SettingHandler) Reset(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, settingMapper.ToResourceCollection(updatedSettings))
+	return response.SuccessResponse(c, mapper.ToSettingResourceCollection(updatedSettings))
 }

--- a/internal/api/handlers/table.go
+++ b/internal/api/handlers/table.go
@@ -2,21 +2,21 @@ package handlers
 
 import (
 	"fluxton/internal/api/dto"
-	"fluxton/internal/api/dto/database"
-	databaseMapper "fluxton/internal/api/mapper/database"
+	databaseDto "fluxton/internal/api/dto/database"
+	"fluxton/internal/api/mapper"
 	"fluxton/internal/api/response"
-	databaseDomain "fluxton/internal/domain/database"
+	"fluxton/internal/domain/database"
 	"fluxton/pkg/auth"
 	"github.com/labstack/echo/v4"
 	"github.com/samber/do"
 )
 
 type TableHandler struct {
-	tableService databaseDomain.TableService
+	tableService database.TableService
 }
 
 func NewTableHandler(injector *do.Injector) (*TableHandler, error) {
-	tableService := do.MustInvoke[databaseDomain.TableService](injector)
+	tableService := do.MustInvoke[database.TableService](injector)
 
 	return &TableHandler{tableService: tableService}, nil
 }
@@ -52,7 +52,7 @@ func (th *TableHandler) List(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, databaseMapper.ToTableResourceCollection(tables))
+	return response.SuccessResponse(c, mapper.ToTableResourceCollection(tables))
 }
 
 // Show retrieves details of a specific table.
@@ -94,7 +94,7 @@ func (th *TableHandler) Show(c echo.Context) error {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, databaseMapper.ToTableResource(&table))
+	return response.SuccessResponse(c, mapper.ToTableResource(&table))
 }
 
 // Store creates a new table within a project.
@@ -119,19 +119,19 @@ func (th *TableHandler) Show(c echo.Context) error {
 //
 // @Router /tables [post]
 func (th *TableHandler) Store(c echo.Context) error {
-	var request database.CreateTableRequest
+	var request databaseDto.CreateTableRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
 
 	authUser, _ := auth.NewAuth(c).User()
 
-	table, err := th.tableService.Create(database.ToCreateTableInput(request), authUser)
+	table, err := th.tableService.Create(databaseDto.ToCreateTableInput(request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.CreatedResponse(c, databaseMapper.ToTableResource(&table))
+	return response.CreatedResponse(c, mapper.ToTableResource(&table))
 }
 
 // Upload creates a new table within a project using uploaded file
@@ -156,19 +156,19 @@ func (th *TableHandler) Store(c echo.Context) error {
 //
 // @Router /tables/upload [post]
 func (th *TableHandler) Upload(c echo.Context) error {
-	var request database.UploadTableRequest
+	var request databaseDto.UploadTableRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
 
 	authUser, _ := auth.NewAuth(c).User()
 
-	table, err := th.tableService.Upload(database.ToUploadTableInput(request), authUser)
+	table, err := th.tableService.Upload(databaseDto.ToUploadTableInput(request), authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.CreatedResponse(c, databaseMapper.ToTableResource(&table))
+	return response.CreatedResponse(c, mapper.ToTableResource(&table))
 }
 
 // Duplicate creates a duplicate of an existing table.
@@ -194,7 +194,7 @@ func (th *TableHandler) Upload(c echo.Context) error {
 //
 // @Router /tables/{tableUUID}/duplicate [put]
 func (th *TableHandler) Duplicate(c echo.Context) error {
-	var request database.RenameTableRequest
+	var request databaseDto.RenameTableRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
@@ -206,12 +206,12 @@ func (th *TableHandler) Duplicate(c echo.Context) error {
 		return response.BadRequestResponse(c, "Table name is required")
 	}
 
-	duplicatedTable, err := th.tableService.Duplicate(fullTableName, authUser, database.ToRenameTableInput(request))
+	duplicatedTable, err := th.tableService.Duplicate(fullTableName, authUser, databaseDto.ToRenameTableInput(request))
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, databaseMapper.ToTableResource(duplicatedTable))
+	return response.SuccessResponse(c, mapper.ToTableResource(duplicatedTable))
 }
 
 // Rename updates the name of an existing table.
@@ -237,7 +237,7 @@ func (th *TableHandler) Duplicate(c echo.Context) error {
 //
 // @Router /tables/{tableUUID}/rename [put]
 func (th *TableHandler) Rename(c echo.Context) error {
-	var request database.RenameTableRequest
+	var request databaseDto.RenameTableRequest
 	if err := request.BindAndValidate(c); err != nil {
 		return response.UnprocessableResponse(c, err)
 	}
@@ -249,12 +249,12 @@ func (th *TableHandler) Rename(c echo.Context) error {
 		return response.BadRequestResponse(c, "Table name is required")
 	}
 
-	renamedTable, err := th.tableService.Rename(fullTableName, authUser, database.ToRenameTableInput(request))
+	renamedTable, err := th.tableService.Rename(fullTableName, authUser, databaseDto.ToRenameTableInput(request))
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}
 
-	return response.SuccessResponse(c, databaseMapper.ToTableResource(&renamedTable))
+	return response.SuccessResponse(c, mapper.ToTableResource(&renamedTable))
 }
 
 // Delete removes a table permanently from a project.

--- a/internal/api/mapper/backup.go
+++ b/internal/api/mapper/backup.go
@@ -1,11 +1,11 @@
-package backup
+package mapper
 
 import (
 	backupDto "fluxton/internal/api/dto/backup"
 	"fluxton/internal/domain/backup"
 )
 
-func ToResource(backup *backup.Backup) backupDto.Response {
+func ToBackupResource(backup *backup.Backup) backupDto.Response {
 	completedAt := ""
 	if backup.CompletedAt != nil {
 		completedAt = backup.CompletedAt.Format("2006-01-02 15:04:05")
@@ -21,10 +21,10 @@ func ToResource(backup *backup.Backup) backupDto.Response {
 	}
 }
 
-func ToResourceCollection(backups []backup.Backup) []backupDto.Response {
+func ToBackupResourceCollection(backups []backup.Backup) []backupDto.Response {
 	resourceBackups := make([]backupDto.Response, len(backups))
 	for i, currentBackup := range backups {
-		resourceBackups[i] = ToResource(&currentBackup)
+		resourceBackups[i] = ToBackupResource(&currentBackup)
 	}
 
 	return resourceBackups

--- a/internal/api/mapper/column.go
+++ b/internal/api/mapper/column.go
@@ -1,4 +1,4 @@
-package database
+package mapper
 
 import (
 	databaseDto "fluxton/internal/api/dto/database"

--- a/internal/api/mapper/container.go
+++ b/internal/api/mapper/container.go
@@ -1,11 +1,11 @@
-package container
+package mapper
 
 import (
 	containerDto "fluxton/internal/api/dto/storage/container"
 	containerDomain "fluxton/internal/domain/storage/container"
 )
 
-func ToResource(container *containerDomain.Container) containerDto.Response {
+func ToContainerResource(container *containerDomain.Container) containerDto.Response {
 	return containerDto.Response{
 		Uuid:        container.Uuid,
 		ProjectUuid: container.ProjectUuid,
@@ -22,10 +22,10 @@ func ToResource(container *containerDomain.Container) containerDto.Response {
 	}
 }
 
-func ToResourceCollection(containers []containerDomain.Container) []containerDto.Response {
+func ToContainerResourceCollection(containers []containerDomain.Container) []containerDto.Response {
 	resourceContainers := make([]containerDto.Response, len(containers))
 	for i, currentContainer := range containers {
-		resourceContainers[i] = ToResource(&currentContainer)
+		resourceContainers[i] = ToContainerResource(&currentContainer)
 	}
 
 	return resourceContainers

--- a/internal/api/mapper/file.go
+++ b/internal/api/mapper/file.go
@@ -1,11 +1,11 @@
-package file
+package mapper
 
 import (
 	fileDto "fluxton/internal/api/dto/storage/file"
 	fileDomain "fluxton/internal/domain/storage/file"
 )
 
-func ToResource(file *fileDomain.File) fileDto.Response {
+func ToFileResource(file *fileDomain.File) fileDto.Response {
 	return fileDto.Response{
 		Uuid:          file.Uuid,
 		ContainerUuid: file.ContainerUuid,
@@ -19,10 +19,10 @@ func ToResource(file *fileDomain.File) fileDto.Response {
 	}
 }
 
-func ToResourceCollection(files []fileDomain.File) []fileDto.Response {
+func ToFileResourceCollection(files []fileDomain.File) []fileDto.Response {
 	resourceContainers := make([]fileDto.Response, len(files))
 	for i, currentFile := range files {
-		resourceContainers[i] = ToResource(&currentFile)
+		resourceContainers[i] = ToFileResource(&currentFile)
 	}
 
 	return resourceContainers

--- a/internal/api/mapper/form.go
+++ b/internal/api/mapper/form.go
@@ -1,4 +1,4 @@
-package form
+package mapper
 
 import (
 	formDto "fluxton/internal/api/dto/form"

--- a/internal/api/mapper/function.go
+++ b/internal/api/mapper/function.go
@@ -1,4 +1,4 @@
-package database
+package mapper
 
 import (
 	databaseDto "fluxton/internal/api/dto/database"

--- a/internal/api/mapper/log.go
+++ b/internal/api/mapper/log.go
@@ -1,11 +1,11 @@
-package logging
+package mapper
 
 import (
 	logDto "fluxton/internal/api/dto/logging"
 	logDomain "fluxton/internal/domain/logging"
 )
 
-func ToResource(log *logDomain.RequestLog) logDto.Response {
+func ToLoggingResource(log *logDomain.RequestLog) logDto.Response {
 	return logDto.Response{
 		Uuid:      log.Uuid,
 		UserUuid:  log.UserUuid,
@@ -20,10 +20,10 @@ func ToResource(log *logDomain.RequestLog) logDto.Response {
 	}
 }
 
-func ToResourceCollection(files []logDomain.RequestLog) []logDto.Response {
+func ToLoggingResourceCollection(files []logDomain.RequestLog) []logDto.Response {
 	resourceContainers := make([]logDto.Response, len(files))
 	for i, currentFile := range files {
-		resourceContainers[i] = ToResource(&currentFile)
+		resourceContainers[i] = ToLoggingResource(&currentFile)
 	}
 
 	return resourceContainers

--- a/internal/api/mapper/organization.go
+++ b/internal/api/mapper/organization.go
@@ -1,11 +1,11 @@
-package organization
+package mapper
 
 import (
 	organizationDto "fluxton/internal/api/dto/organization"
 	organizationDomain "fluxton/internal/domain/organization"
 )
 
-func ToResource(organization *organizationDomain.Organization) organizationDto.Response {
+func ToOrganizationResource(organization *organizationDomain.Organization) organizationDto.Response {
 	return organizationDto.Response{
 		Uuid:      organization.Uuid,
 		Name:      organization.Name,
@@ -16,10 +16,10 @@ func ToResource(organization *organizationDomain.Organization) organizationDto.R
 	}
 }
 
-func ToResourceCollection(organizations []organizationDomain.Organization) []organizationDto.Response {
+func ToOrganizationResourceCollection(organizations []organizationDomain.Organization) []organizationDto.Response {
 	resourceNotes := make([]organizationDto.Response, len(organizations))
 	for i, organization := range organizations {
-		resourceNotes[i] = ToResource(&organization)
+		resourceNotes[i] = ToOrganizationResource(&organization)
 	}
 
 	return resourceNotes

--- a/internal/api/mapper/project.go
+++ b/internal/api/mapper/project.go
@@ -1,11 +1,11 @@
-package project
+package mapper
 
 import (
 	projectDto "fluxton/internal/api/dto/project"
 	projectDomain "fluxton/internal/domain/project"
 )
 
-func ToResource(project *projectDomain.Project) projectDto.Response {
+func ToProjectResource(project *projectDomain.Project) projectDto.Response {
 	return projectDto.Response{
 		Uuid:             project.Uuid,
 		OrganizationUuid: project.OrganizationUuid,
@@ -20,10 +20,10 @@ func ToResource(project *projectDomain.Project) projectDto.Response {
 	}
 }
 
-func ToResourceCollection(projects []projectDomain.Project) []projectDto.Response {
+func ToProjectResourceCollection(projects []projectDomain.Project) []projectDto.Response {
 	resourceNotes := make([]projectDto.Response, len(projects))
 	for i, currentProject := range projects {
-		resourceNotes[i] = ToResource(&currentProject)
+		resourceNotes[i] = ToProjectResource(&currentProject)
 	}
 
 	return resourceNotes

--- a/internal/api/mapper/setting.go
+++ b/internal/api/mapper/setting.go
@@ -1,11 +1,11 @@
-package setting
+package mapper
 
 import (
 	settingDto "fluxton/internal/api/dto/setting"
 	settingDomain "fluxton/internal/domain/setting"
 )
 
-func ToResource(setting *settingDomain.Setting) settingDto.Response {
+func ToSettingResource(setting *settingDomain.Setting) settingDto.Response {
 	return settingDto.Response{
 		ID:           setting.ID,
 		Name:         setting.Name,
@@ -16,11 +16,11 @@ func ToResource(setting *settingDomain.Setting) settingDto.Response {
 	}
 }
 
-func ToResourceCollection(settings []settingDomain.Setting) []settingDto.Response {
-	resourcesettings := make([]settingDto.Response, len(settings))
+func ToSettingResourceCollection(settings []settingDomain.Setting) []settingDto.Response {
+	settingResource := make([]settingDto.Response, len(settings))
 	for i, currentSetting := range settings {
-		resourcesettings[i] = ToResource(&currentSetting)
+		settingResource[i] = ToSettingResource(&currentSetting)
 	}
 
-	return resourcesettings
+	return settingResource
 }

--- a/internal/api/mapper/table.go
+++ b/internal/api/mapper/table.go
@@ -1,4 +1,4 @@
-package database
+package mapper
 
 import (
 	databaseDto "fluxton/internal/api/dto/database"

--- a/internal/api/mapper/user.go
+++ b/internal/api/mapper/user.go
@@ -1,11 +1,11 @@
-package user
+package mapper
 
 import (
 	userDto "fluxton/internal/api/dto/user"
 	userDomain "fluxton/internal/domain/user"
 )
 
-func ToResponse(user *userDomain.User) userDto.Response {
+func ToUserResource(user *userDomain.User) userDto.Response {
 	return userDto.Response{
 		Uuid:      user.Uuid,
 		Username:  user.Username,
@@ -18,10 +18,10 @@ func ToResponse(user *userDomain.User) userDto.Response {
 	}
 }
 
-func ToResponseCollection(users []userDomain.User) []userDto.Response {
+func ToUserResourceCollection(users []userDomain.User) []userDto.Response {
 	resourceUsers := make([]userDto.Response, len(users))
 	for i, currentUser := range users {
-		resourceUsers[i] = ToResponse(&currentUser)
+		resourceUsers[i] = ToUserResource(&currentUser)
 	}
 
 	return resourceUsers


### PR DESCRIPTION
The response mappers directory is not optimal. There is dedicated directory for each type and mostly contains a file with two methods. These are found at `internal/api/mapper`

This PR will throw away directories and put all files in same directory. 

**Before**
```go
projectMapper "fluxton/internal/api/mapper/project"
projectMapper.ToResource
```


**After**
```go
"fluxton/internal/api/mapper"
mapper.ToProjectResource
```

