### PR TITLE
[FLX-16] Support log search

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,11 @@ RUN apk add --no-cache docker
 WORKDIR /app
 COPY . .
 
-# Install dependencies
+# Install dependencies for Go application
 RUN go mod tidy
 
-# Build the Go app using your specific build command
+# Build the Go app using your specific build command. This builds for Linux amd64 architecture.
+# We don't use CROSS platform binary to reduce overall size
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -trimpath -o bin/fluxton cmd/main.go
 
 # Expose the port Echo is running on (change if needed)

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ Fluxton is a fast, no BS backend server built with Go. It cuts the noise and giv
 - Built-in Org & Role Management
 - Instantly Generated Endpoints
 - Plug-and-Play Auth
-- Built-in Search Engine
 - Realtime Database
-- Zapier Integration
 - Row-Level Access Control
 - Import CSV/XLSX as APIs
 - DB Functions, Triggers & Hooks
 - Smart Forms with Validations & Triggers
 - Multi-Driver Storage (S3, Dropbox, BackBlaze, FS)
 - Detailed Audit Logs
+- Built-in Search Engine (upcoming)
+- Zapier Integration (upcoming)
 - And much much more
 
 ## How it works

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -42,6 +42,36 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
+                        "description": "Filter by user UUID",
+                        "name": "userUuid",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by HTTP method",
+                        "name": "method",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by endpoint",
+                        "name": "endpoint",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by IP address",
+                        "name": "ipAddress",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Page number for pagination",
                         "name": "page",
                         "in": "query"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -36,6 +36,36 @@
                     },
                     {
                         "type": "string",
+                        "description": "Filter by user UUID",
+                        "name": "userUuid",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by status",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by HTTP method",
+                        "name": "method",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by endpoint",
+                        "name": "endpoint",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter by IP address",
+                        "name": "ipAddress",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
                         "description": "Page number for pagination",
                         "name": "page",
                         "in": "query"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -561,6 +561,26 @@ paths:
         name: Authorization
         required: true
         type: string
+      - description: Filter by user UUID
+        in: query
+        name: userUuid
+        type: string
+      - description: Filter by status
+        in: query
+        name: status
+        type: string
+      - description: Filter by HTTP method
+        in: query
+        name: method
+        type: string
+      - description: Filter by endpoint
+        in: query
+        name: endpoint
+        type: string
+      - description: Filter by IP address
+        in: query
+        name: ipAddress
+        type: string
       - description: Page number for pagination
         in: query
         name: page

--- a/internal/api/dto/logging/mapper.go
+++ b/internal/api/dto/logging/mapper.go
@@ -2,15 +2,14 @@ package logging
 
 import (
 	"fluxton/internal/domain/logging"
-	"github.com/guregu/null/v6"
 )
 
 func ToLogListInput(request *ListRequest) *logging.ListInput {
 	return &logging.ListInput{
-		UserUuid:  null.StringFrom(request.UserUuid),
-		Status:    null.StringFrom(request.Status),
-		Method:    null.StringFrom(request.Method),
-		Endpoint:  null.StringFrom(request.Endpoint),
-		IPAddress: null.StringFrom(request.IPAddress),
+		UserUuid:  request.UserUuid,
+		Status:    request.Status,
+		Method:    request.Method,
+		Endpoint:  request.Endpoint,
+		IPAddress: request.IPAddress,
 	}
 }

--- a/internal/api/dto/logging/mapper.go
+++ b/internal/api/dto/logging/mapper.go
@@ -1,0 +1,16 @@
+package logging
+
+import (
+	"fluxton/internal/domain/logging"
+	"github.com/guregu/null/v6"
+)
+
+func ToLogListInput(request *ListRequest) *logging.ListInput {
+	return &logging.ListInput{
+		UserUuid:  null.StringFrom(request.UserUuid),
+		Status:    null.StringFrom(request.Status),
+		Method:    null.StringFrom(request.Method),
+		Endpoint:  null.StringFrom(request.Endpoint),
+		IPAddress: null.StringFrom(request.IPAddress),
+	}
+}

--- a/internal/api/dto/logging/requests.go
+++ b/internal/api/dto/logging/requests.go
@@ -2,16 +2,18 @@ package logging
 
 import (
 	"fluxton/internal/api/dto"
+	"github.com/google/uuid"
+	"github.com/guregu/null/v6"
 	"github.com/labstack/echo/v4"
 )
 
 type ListRequest struct {
 	dto.BaseRequest
-	UserUuid  string `query:"userUuid"`
-	Status    string `query:"status"`
-	Method    string `query:"method"`
-	Endpoint  string `query:"endpoint"`
-	IPAddress string `query:"ipAddress"`
+	UserUuid  uuid.NullUUID `query:"userUuid"`
+	Status    null.String   `query:"status"`
+	Method    null.String   `query:"method"`
+	Endpoint  null.String   `query:"endpoint"`
+	IPAddress null.String   `query:"ipAddress"`
 
 	Limit int    `query:"limit"`
 	Page  int    `query:"page"`

--- a/internal/api/handlers/log.go
+++ b/internal/api/handlers/log.go
@@ -31,6 +31,12 @@ func NewLogHandler(injector *do.Injector) (*LogHandler, error) {
 //
 // @Param Authorization header string true "Bearer Token"
 //
+// @Param userUuid query string false "Filter by user UUID"
+// @Param status query string false "Filter by status"
+// @Param method query string false "Filter by HTTP method"
+// @Param endpoint query string false "Filter by endpoint"
+// @Param ipAddress query string false "Filter by IP address"
+//
 // @Param page query string false "Page number for pagination"
 // @Param limit query string false "Number of items per page"
 // @Param sort query string false "Field to sort by"

--- a/internal/api/handlers/log.go
+++ b/internal/api/handlers/log.go
@@ -51,7 +51,7 @@ func (lh *LogHandler) List(c echo.Context) error {
 	authUser, _ := auth.NewAuth(c).User()
 
 	paginationParams := request.ExtractPaginationParams(c)
-	logs, err := lh.logService.List(paginationParams, authUser)
+	logs, err := lh.logService.List(loggingDto.ToLogListInput(&request), paginationParams, authUser)
 	if err != nil {
 		return response.ErrorResponse(c, err)
 	}

--- a/internal/database/repositories/container.go
+++ b/internal/database/repositories/container.go
@@ -39,7 +39,7 @@ func (r *ContainerRepository) ListForProject(paginationParams shared.PaginationP
 
 	`
 
-	query = fmt.Sprintf(query, pkg.GetColumns[container.Container]())
+	query = fmt.Sprintf(query, pkg.GetColumns[container.Container]()) // dynamically pulls columns from entity
 
 	params := map[string]interface{}{
 		"project_uuid": projectUUID,

--- a/internal/database/repositories/request_log.go
+++ b/internal/database/repositories/request_log.go
@@ -31,7 +31,7 @@ func (r *RequestLogRepository) List(input *logging.ListInput, paginationParams s
 
 	if input.UserUuid.Valid {
 		filters = append(filters, "user_uuid = :user_uuid")
-		params["user_uuid"] = input.UserUuid
+		params["user_uuid"] = input.UserUuid.UUID.String()
 	}
 
 	if input.Status.Valid {

--- a/internal/database/repositories/request_log.go
+++ b/internal/database/repositories/request_log.go
@@ -4,8 +4,10 @@ import (
 	"fluxton/internal/domain/logging"
 	"fluxton/internal/domain/shared"
 	"fluxton/pkg"
+	"fmt"
 	"github.com/jmoiron/sqlx"
 	"github.com/samber/do"
+	"strings"
 )
 
 type RequestLogRepository struct {
@@ -18,15 +20,56 @@ func NewRequestLogRepository(injector *do.Injector) (logging.Repository, error) 
 	return &RequestLogRepository{db: db}, nil
 }
 
-func (r *RequestLogRepository) List(paginationParams shared.PaginationParams) ([]logging.RequestLog, error) {
-	offset := (paginationParams.Page - 1) * paginationParams.Limit
-	query := `SELECT * FROM fluxton.api_logs ORDER BY :sort DESC LIMIT :limit OFFSET :offset;`
+func (r *RequestLogRepository) List(input *logging.ListInput, paginationParams shared.PaginationParams) ([]logging.RequestLog, error) {
+	var filters []string
 
+	offset := (paginationParams.Page - 1) * paginationParams.Limit
 	params := map[string]interface{}{
-		"sort":   paginationParams.Sort,
 		"limit":  paginationParams.Limit,
 		"offset": offset,
 	}
+
+	if input.UserUuid.Valid {
+		filters = append(filters, "user_uuid = :user_uuid")
+		params["user_uuid"] = input.UserUuid
+	}
+
+	if input.Status.Valid {
+		filters = append(filters, "status = :status")
+		params["status"] = input.Status
+	}
+
+	if input.Method.Valid {
+		filters = append(filters, "method = :method")
+		params["method"] = input.Method
+	}
+
+	if input.Endpoint.Valid {
+		filters = append(filters, "endpoint = :endpoint")
+		params["endpoint"] = input.Endpoint
+	}
+
+	if input.IPAddress.Valid {
+		filters = append(filters, "ip_address = :ip_address")
+		params["ip_address"] = input.IPAddress
+	}
+
+	query := `SELECT * FROM fluxton.api_logs`
+	if len(filters) > 0 {
+		query += " WHERE " + strings.Join(filters, " AND ")
+	}
+
+	allowedSorts := map[string]bool{
+		"created_at": true,
+		"status":     true,
+		"method":     true,
+	}
+	sortColumn := "created_at" // default
+	if allowedSorts[paginationParams.Sort] {
+		sortColumn = paginationParams.Sort
+	}
+
+	query += fmt.Sprintf(" ORDER BY %s DESC LIMIT :limit OFFSET :offset", sortColumn)
 
 	rows, err := r.db.NamedQuery(query, params)
 	if err != nil {

--- a/internal/domain/logging/repository.go
+++ b/internal/domain/logging/repository.go
@@ -5,6 +5,6 @@ import (
 )
 
 type Repository interface {
-	List(paginationParams shared.PaginationParams) ([]RequestLog, error)
+	List(input *ListInput, paginationParams shared.PaginationParams) ([]RequestLog, error)
 	Create(requestLog *RequestLog) (*RequestLog, error)
 }

--- a/internal/domain/logging/service.go
+++ b/internal/domain/logging/service.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Service interface {
-	List(paginationParams shared.PaginationParams, authUser auth.User) ([]RequestLog, error)
+	List(listInput *ListInput, paginationParams shared.PaginationParams, authUser auth.User) ([]RequestLog, error)
 }
 
 type ServiceImpl struct {
@@ -27,10 +27,10 @@ func NewLogService(injector *do.Injector) (Service, error) {
 	}, nil
 }
 
-func (s *ServiceImpl) List(paginationParams shared.PaginationParams, authUser auth.User) ([]RequestLog, error) {
+func (s *ServiceImpl) List(listInput *ListInput, paginationParams shared.PaginationParams, authUser auth.User) ([]RequestLog, error) {
 	if !s.adminPolicy.CanAccess(authUser) {
 		return []RequestLog{}, errors.NewForbiddenError("log.error.listForbidden")
 	}
 
-	return s.logRepo.List(paginationParams)
+	return s.logRepo.List(listInput, paginationParams)
 }

--- a/internal/domain/logging/types.go
+++ b/internal/domain/logging/types.go
@@ -1,13 +1,14 @@
 package logging
 
 import (
+	"github.com/google/uuid"
 	"github.com/guregu/null/v6"
 )
 
 type ListInput struct {
-	UserUuid  null.String `query:"userUuid"`
-	Status    null.String `query:"status"`
-	Method    null.String `query:"method"`
-	Endpoint  null.String `query:"endpoint"`
-	IPAddress null.String `query:"ipAddress"`
+	UserUuid  uuid.NullUUID `query:"userUuid"`
+	Status    null.String   `query:"status"`
+	Method    null.String   `query:"method"`
+	Endpoint  null.String   `query:"endpoint"`
+	IPAddress null.String   `query:"ipAddress"`
 }

--- a/internal/domain/logging/types.go
+++ b/internal/domain/logging/types.go
@@ -1,0 +1,13 @@
+package logging
+
+import (
+	"github.com/guregu/null/v6"
+)
+
+type ListInput struct {
+	UserUuid  null.String `query:"userUuid"`
+	Status    null.String `query:"status"`
+	Method    null.String `query:"method"`
+	Endpoint  null.String `query:"endpoint"`
+	IPAddress null.String `query:"ipAddress"`
+}


### PR DESCRIPTION
**Context**
We will be supporting logs. Users should be able to view request logs and also filter through them with different parameters.

**What changes**
Allow `GET` => `api/admin/logs` users to search by different parameters. These parameters include
- `userUuid`: all request from a specific user
- `status`: all request with HTTP status e.g `200`
- `method`: all requests with HTTP method e.g `POST`
- `endpoint`: all requests to an endpoint
- `ipAddress:` all request from an IP
- `limit`: number of results per page
- `page`: current page
- `sort`: sort results by
- `order`: order results by

[Source](https://github.com/fluxton-io/fluxton/blob/f6b36ee0ed665c45a0f445f9fc7180221b1aa7ad/internal/api/dto/logging/requests.go#L13)