### PR TITLE
Fix: Remove alternating column colors in tables

### DIFF
--- a/web/app/routes/tables/columns.tsx
+++ b/web/app/routes/tables/columns.tsx
@@ -274,14 +274,12 @@ export const prepareColumns = (
     },
     meta: {
       isSticky: true,
-      isEven: false,
     },
   };
 
   // Create the data columns
   const dataColumns = Array.isArray(columns)
     ? columns.filter(Boolean).map((column, index) => {
-        const isEvenColumn = index % 2 === 0;
         const dataType = column.type || "";
         const isTimestamp = dataType.includes("timestamp");
         const columnId = column.name;
@@ -354,7 +352,6 @@ export const prepareColumns = (
             );
           },
           meta: {
-            isEven: isEvenColumn,
             collectionName,
           },
         };

--- a/web/app/routes/tables/data-table.tsx
+++ b/web/app/routes/tables/data-table.tsx
@@ -93,12 +93,6 @@ export function DataTable<TData, TValue>({
                         "sticky-column":
                           header.column.columnDef.meta &&
                           (header.column.columnDef.meta as any).isSticky,
-                        "bg-background":
-                          header.column.columnDef.meta &&
-                          (header.column.columnDef.meta as any)?.isEven,
-                        "bg-muted/50":
-                          header.column.columnDef.meta &&
-                          !(header.column.columnDef.meta as any)?.isEven,
                       })}
                     >
                       {header.isPlaceholder
@@ -137,12 +131,6 @@ export function DataTable<TData, TValue>({
                           "sticky-column":
                             cell.column.columnDef.meta &&
                             (cell.column.columnDef.meta as any).isSticky,
-                          "bg-background":
-                            cell.column.columnDef.meta &&
-                            (cell.column.columnDef.meta as any)?.isEven,
-                          "bg-muted/50":
-                            cell.column.columnDef.meta &&
-                            !(cell.column.columnDef.meta as any)?.isEven,
                         })}
                       >
                         {flexRender(


### PR DESCRIPTION
## Summary
- Removes alternating grey/white column colors from data tables
- Creates a clean, consistent appearance across all columns
- Maintains row hover effects and sticky column functionality

## Changes Made
1. Removed `bg-background` and `bg-muted/50` classes from table headers and cells in `data-table.tsx`
2. Removed `isEven` property from column meta data in `columns.tsx`
3. Cleaned up unused `isEvenColumn` variable

## Testing
- Verified that all columns now have consistent background color
- Confirmed row hover effects still work
- Tested with both light and dark themes
- Ensured sticky columns still function properly

Fixes #123