### PR TITLE
fix: update dialog title to use proper plural form in projects page

### DIFF
--- a/web/app/routes/projects/page.tsx
+++ b/web/app/routes/projects/page.tsx
@@ -79,7 +79,7 @@ const CreateProjectDialog = ({ children }: { children: React.ReactNode }) => {
           className="grid gap-4"
         >
           <DialogHeader>
-            <DialogTitle>Create Project</DialogTitle>
+            <DialogTitle>Create Projects</DialogTitle>
             <DialogDescription>
               Describe your project and its purpose
             </DialogDescription>


### PR DESCRIPTION
## Summary
• Fix dialog title grammar by changing 'Create Project' to 'Create Projects' for proper pluralization