### PR TITLE
fix: add platform linux/amd64 for api and frontend images on ARM64

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
 
   fluxend_api:
     image: fluxend/api:latest
+    platform: linux/amd64
     container_name: fluxend_api
     restart: always
     environment:
@@ -68,6 +69,7 @@ services:
 
   fluxend_frontend:
     image: fluxend/frontend:latest
+    platform: linux/amd64
     container_name: fluxend_frontend
     restart: always
     environment:


### PR DESCRIPTION
## What

Adds `platform: linux/amd64` to the `fluxend_api` and `fluxend_frontend` services in `docker-compose.yml`. The published images are AMD64-only, which causes `make setup` to fail on Apple Silicon Macs with "no matching manifest for linux/arm64/v8".

## Changes

- Set `platform: linux/amd64` on `fluxend_api` service
- Set `platform: linux/amd64` on `fluxend_frontend` service
