### PR TITLE
chore: pin postgres image to version 17

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - fluxend_frontend
 
   fluxend_db:
-    image: postgres:latest
+    image: postgres:17
     container_name: fluxend_db
     restart: always
     environment:


### PR DESCRIPTION
## What

Pins the `fluxend_db` image from `postgres:latest` to `postgres:17`. The `latest` tag recently resolved to Postgres 18, which changed the expected volume mount path and broke container startup.

## Changes

- Replace `postgres:latest` with `postgres:17` in `docker-compose.yml`

## Test plan

- [ ] Run `docker-compose up -d` and confirm `fluxend_db` reaches healthy status
- [ ] Confirm `make setup` completes without the unhealthy container error