### PR TITLE
feat: FLX-158 webhooks on table events

### DIFF
--- a/WEBHOOKS.md
+++ b/WEBHOOKS.md
@@ -1,0 +1,65 @@
+# FLX-158 — Webhooks on Table Events
+
+## Architecture
+
+Row mutations (INSERT/UPDATE/DELETE) route through new Fluxend API proxy endpoints. Frontend calls Fluxend API → Fluxend proxies to PostgREST internally (`http://postgrest_{dbName}:3000/`) → captures mutated row(s) → fires webhooks synchronously → returns PostgREST response to client. READ operations remain direct PostgREST calls.
+
+## Payload Shape
+
+```json
+{
+  "event": "insert",
+  "table": "orders",
+  "project": "uuid-here",
+  "timestamp": "2026-06-25T10:00:00Z",
+  "record": { "id": 1, "name": "Example row" }
+}
+```
+
+## Backend
+
+### Migration
+`internal/database/migrations/{timestamp}_add_webhook_configs_table.sql`
+- Table: `fluxend.webhook_configs` (uuid, project_uuid, table_name, url, events TEXT[], is_active, created_by, updated_by, created_at, updated_at)
+- FK: project_uuid → fluxend.projects(uuid) ON DELETE CASCADE
+
+### Domain `internal/domain/webhook/`
+- `entity.go` — `WebhookConfig` struct + `Response` struct
+- `repository.go` — `ListForTable`, `ListActiveForTableAndEvent`, `GetByUUID`, `ExistsByUUID`, `Create`, `Delete`
+- `service.go` — `List`, `Create`, `Delete`, `Fire` (fires POST to configured URLs)
+- `policy.go` — authorization against project membership
+
+### Repository
+`internal/database/repositories/webhook.go` — use `pq.Array()` for events TEXT[]
+
+### Row Proxy Handler
+`internal/api/handlers/row.go` — `Insert`, `Update`, `Delete` methods
+- Extracts project UUID from `X-Project` header → fetches project → gets `dbName`
+- Forwards request to `http://postgrest_{dbName}:3000/{tableName}` with `Prefer: return=representation`
+- Calls `webhookService.Fire()` with returned row data
+- Returns PostgREST status + body to client
+
+Routes: `POST|PATCH|DELETE /tables/:tableName/rows`
+
+### Webhook Config Handler
+`internal/api/handlers/webhook.go` — `List`, `Store`, `Delete`
+
+Routes: `GET|POST /tables/:tableName/webhooks`, `DELETE /tables/:tableName/webhooks/:webhookUUID`
+
+### DTO, Mapper, Routes, DI
+- `internal/api/dto/webhook_dto.go` — `StoreRequest` (url, events, is_active)
+- `internal/api/mapper/webhook.go`
+- `internal/api/routes/webhook.go` + `internal/api/routes/row.go`
+- Update `internal/app/commands/server.go` and `internal/app/container.go`
+
+## Frontend
+
+### Update Row Mutations `web/app/services/tables.ts`
+- `updateTableRow` / `deleteTableRows` — route through Fluxend API instead of PostgREST directly
+- Add `createTableRow` — `POST /tables/{tableName}/rows`
+
+### Webhook Config UI
+- `web/app/routes/tables/webhooks.tsx` — list + add webhook form
+- `web/app/services/webhooks.ts` — listWebhooks, createWebhook, deleteWebhook
+- `web/app/routes/tables/sidebar.tsx` — add Webhooks nav item
+- `web/app/routes.ts` — add route entry

--- a/internal/api/dto/webhook/requests.go
+++ b/internal/api/dto/webhook/requests.go
@@ -1,0 +1,46 @@
+package webhook
+
+import (
+	"fluxend/internal/api/dto"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/go-ozzo/ozzo-validation/v4/is"
+	"github.com/labstack/echo/v4"
+)
+
+var allowedEvents = []interface{}{"insert", "update", "delete"}
+
+type CreateRequest struct {
+	dto.DefaultRequestWithProjectHeader
+	URL      string   `json:"url"`
+	Events   []string `json:"events"`
+	IsActive bool     `json:"is_active"`
+}
+
+func (r *CreateRequest) BindAndValidate(c echo.Context) []string {
+	if err := c.Bind(r); err != nil {
+		return []string{"Invalid request payload"}
+	}
+
+	if err := r.WithProjectHeader(c); err != nil {
+		return []string{err.Error()}
+	}
+
+	eventInterfaces := make([]interface{}, len(r.Events))
+	for i, e := range r.Events {
+		eventInterfaces[i] = e
+	}
+
+	err := validation.ValidateStruct(r,
+		validation.Field(&r.URL,
+			validation.Required.Error("URL is required"),
+			is.URL.Error("URL must be a valid URL"),
+		),
+		validation.Field(&r.Events,
+			validation.Required.Error("Events are required"),
+			validation.Length(1, 3).Error("At least one event is required"),
+			validation.Each(validation.In(allowedEvents...).Error("Event must be one of: insert, update, delete")),
+		),
+	)
+
+	return r.ExtractValidationErrors(err)
+}

--- a/internal/api/dto/webhook/responses.go
+++ b/internal/api/dto/webhook/responses.go
@@ -1,0 +1,15 @@
+package webhook
+
+import (
+	"github.com/google/uuid"
+)
+
+type Response struct {
+	Uuid      uuid.UUID `json:"uuid"`
+	TableName string    `json:"tableName"`
+	URL       string    `json:"url"`
+	Events    []string  `json:"events"`
+	IsActive  bool      `json:"isActive"`
+	CreatedAt string    `json:"createdAt"`
+	UpdatedAt string    `json:"updatedAt"`
+}

--- a/internal/api/handlers/row.go
+++ b/internal/api/handlers/row.go
@@ -1,0 +1,177 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fluxend/internal/api/dto"
+	"fluxend/internal/api/response"
+	"fluxend/internal/domain/project"
+	"fluxend/internal/domain/webhook"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/samber/do"
+)
+
+type RowHandler struct {
+	projectRepo    project.Repository
+	webhookService webhook.Service
+	httpClient     *http.Client
+}
+
+func NewRowHandler(injector *do.Injector) (*RowHandler, error) {
+	projectRepo := do.MustInvoke[project.Repository](injector)
+	webhookService := do.MustInvoke[webhook.Service](injector)
+
+	return &RowHandler{
+		projectRepo:    projectRepo,
+		webhookService: webhookService,
+		httpClient:     &http.Client{Timeout: 30 * time.Second},
+	}, nil
+}
+
+// Insert proxies a row INSERT to PostgREST and fires webhooks
+//
+// @Summary Insert row
+// @Description Insert a row into a table via the Fluxend proxy
+// @Tags Rows
+//
+// @Accept json
+// @Produce json
+//
+// @Param Authorization header string true "Bearer Token"
+// @Param X-Project header string true "Project UUID"
+// @Param fullTableName path string true "Full table name (e.g. public.orders)"
+//
+// @Success 201 "Row created"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
+//
+// @Router /tables/{fullTableName}/rows [post]
+func (rh *RowHandler) Insert(c echo.Context) error {
+	return rh.proxy(c, "insert")
+}
+
+// Update proxies a row UPDATE to PostgREST and fires webhooks
+//
+// @Summary Update rows
+// @Description Update rows in a table via the Fluxend proxy
+// @Tags Rows
+//
+// @Accept json
+// @Produce json
+//
+// @Param Authorization header string true "Bearer Token"
+// @Param X-Project header string true "Project UUID"
+// @Param fullTableName path string true "Full table name (e.g. public.orders)"
+//
+// @Success 200 "Rows updated"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
+//
+// @Router /tables/{fullTableName}/rows [patch]
+func (rh *RowHandler) Update(c echo.Context) error {
+	return rh.proxy(c, "update")
+}
+
+// Delete proxies a row DELETE to PostgREST and fires webhooks
+//
+// @Summary Delete rows
+// @Description Delete rows from a table via the Fluxend proxy
+// @Tags Rows
+//
+// @Accept json
+// @Produce json
+//
+// @Param Authorization header string true "Bearer Token"
+// @Param X-Project header string true "Project UUID"
+// @Param fullTableName path string true "Full table name (e.g. public.orders)"
+//
+// @Success 200 "Rows deleted"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
+//
+// @Router /tables/{fullTableName}/rows [delete]
+func (rh *RowHandler) Delete(c echo.Context) error {
+	return rh.proxy(c, "delete")
+}
+
+func (rh *RowHandler) proxy(c echo.Context, event string) error {
+	var baseRequest dto.DefaultRequestWithProjectHeader
+	if err := baseRequest.WithProjectHeader(c); err != nil {
+		return response.BadRequestResponse(c, err.Error())
+	}
+
+	dbName, err := rh.projectRepo.GetDatabaseNameByUUID(baseRequest.ProjectUUID)
+	if err != nil {
+		return response.ErrorResponse(c, err)
+	}
+
+	tableName := extractTableName(c.Param("fullTableName"))
+	postgrestURL := fmt.Sprintf("http://postgrest_%s:3000/%s", dbName, tableName)
+
+	body, err := io.ReadAll(c.Request().Body)
+	if err != nil {
+		return response.BadRequestResponse(c, "Failed to read request body")
+	}
+
+	method := c.Request().Method
+	req, err := http.NewRequest(method, postgrestURL, strings.NewReader(string(body)))
+	if err != nil {
+		return response.BadRequestResponse(c, "Failed to build upstream request")
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Prefer", "return=representation")
+
+	if auth := c.Request().Header.Get("Authorization"); auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+
+	// Forward query params (PostgREST filter syntax: id=eq.1, id=in.(1,2))
+	req.URL.RawQuery = c.Request().URL.RawQuery
+
+	resp, err := rh.httpClient.Do(req)
+	if err != nil {
+		return response.BadRequestResponse(c, "Failed to reach upstream database")
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return response.BadRequestResponse(c, "Failed to read upstream response")
+	}
+
+	// Fire webhooks with the returned row data (best-effort, non-blocking)
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 && len(respBody) > 0 {
+		projectUUID := baseRequest.ProjectUUID
+		go rh.fireWebhooks(projectUUID, tableName, event, respBody)
+	}
+
+	// Mirror PostgREST content-type and status back to the client
+	c.Response().Header().Set("Content-Type", "application/json")
+	return c.Blob(resp.StatusCode, "application/json", respBody)
+}
+
+func (rh *RowHandler) fireWebhooks(projectUUID uuid.UUID, tableName, event string, body []byte) {
+	var records interface{}
+	if err := json.Unmarshal(body, &records); err != nil {
+		return
+	}
+
+	switch v := records.(type) {
+	case []interface{}:
+		for _, record := range v {
+			rh.webhookService.Fire(projectUUID, tableName, event, record)
+		}
+	default:
+		rh.webhookService.Fire(projectUUID, tableName, event, records)
+	}
+}

--- a/internal/api/handlers/webhook.go
+++ b/internal/api/handlers/webhook.go
@@ -1,0 +1,156 @@
+package handlers
+
+import (
+	"fluxend/internal/api/dto"
+	webhookDto "fluxend/internal/api/dto/webhook"
+	"fluxend/internal/api/mapper"
+	"fluxend/internal/api/response"
+	"fluxend/internal/domain/webhook"
+	"fluxend/pkg/auth"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/samber/do"
+	"strings"
+)
+
+type WebhookHandler struct {
+	webhookService webhook.Service
+}
+
+func NewWebhookHandler(injector *do.Injector) (*WebhookHandler, error) {
+	webhookService := do.MustInvoke[webhook.Service](injector)
+
+	return &WebhookHandler{webhookService: webhookService}, nil
+}
+
+// List retrieves all webhooks for a table
+//
+// @Summary List webhooks
+// @Description Retrieve all webhook configurations for a table
+// @Tags Webhooks
+//
+// @Accept json
+// @Produce json
+//
+// @Param Authorization header string true "Bearer Token"
+// @Param X-Project header string true "Project UUID"
+// @Param fullTableName path string true "Full table name (e.g. public.orders)"
+//
+// @Success 200 {array} response.Response{content=[]webhook.Response} "List of webhooks"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
+//
+// @Router /tables/{fullTableName}/webhooks [get]
+func (wh *WebhookHandler) List(c echo.Context) error {
+	var request dto.DefaultRequestWithProjectHeader
+	if err := request.BindAndValidate(c); err != nil {
+		return response.UnprocessableResponse(c, err)
+	}
+
+	authUser, _ := auth.NewAuth(c).User()
+
+	tableName := extractTableName(c.Param("fullTableName"))
+
+	configs, err := wh.webhookService.List(request.ProjectUUID, tableName, authUser)
+	if err != nil {
+		return response.ErrorResponse(c, err)
+	}
+
+	return response.SuccessResponse(c, mapper.ToWebhookResourceCollection(configs))
+}
+
+// Store creates a new webhook for a table
+//
+// @Summary Create webhook
+// @Description Add a new webhook configuration for a table
+// @Tags Webhooks
+//
+// @Accept json
+// @Produce json
+//
+// @Param Authorization header string true "Bearer Token"
+// @Param X-Project header string true "Project UUID"
+// @Param fullTableName path string true "Full table name (e.g. public.orders)"
+// @Param webhook body webhook.CreateRequest true "Webhook URL, events, and active flag"
+//
+// @Success 201 {object} response.Response{content=webhook.Response} "Webhook created"
+// @Failure 422 {object} response.UnprocessableErrorResponse "Unprocessable input response"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
+//
+// @Router /tables/{fullTableName}/webhooks [post]
+func (wh *WebhookHandler) Store(c echo.Context) error {
+	var request webhookDto.CreateRequest
+	if err := request.BindAndValidate(c); err != nil {
+		return response.UnprocessableResponse(c, err)
+	}
+
+	authUser, _ := auth.NewAuth(c).User()
+
+	tableName := extractTableName(c.Param("fullTableName"))
+
+	input := webhook.CreateInput{
+		ProjectUUID: request.ProjectUUID,
+		TableName:   tableName,
+		URL:         request.URL,
+		Events:      request.Events,
+		IsActive:    request.IsActive,
+	}
+
+	created, err := wh.webhookService.Create(input, authUser)
+	if err != nil {
+		return response.ErrorResponse(c, err)
+	}
+
+	return response.CreatedResponse(c, mapper.ToWebhookResponse(&created))
+}
+
+// Delete removes a webhook configuration
+//
+// @Summary Delete webhook
+// @Description Remove a webhook configuration from a table
+// @Tags Webhooks
+//
+// @Accept json
+// @Produce json
+//
+// @Param Authorization header string true "Bearer Token"
+// @Param X-Project header string true "Project UUID"
+// @Param fullTableName path string true "Full table name (e.g. public.orders)"
+// @Param webhookUUID path string true "Webhook UUID"
+//
+// @Success 204 "Webhook deleted"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
+//
+// @Router /tables/{fullTableName}/webhooks/{webhookUUID} [delete]
+func (wh *WebhookHandler) Delete(c echo.Context) error {
+	var request dto.DefaultRequestWithProjectHeader
+	if err := request.BindAndValidate(c); err != nil {
+		return response.UnprocessableResponse(c, err)
+	}
+
+	authUser, _ := auth.NewAuth(c).User()
+
+	webhookUUID, err := uuid.Parse(c.Param("webhookUUID"))
+	if err != nil {
+		return response.BadRequestResponse(c, "Invalid webhook UUID")
+	}
+
+	if _, err := wh.webhookService.Delete(webhookUUID, authUser); err != nil {
+		return response.ErrorResponse(c, err)
+	}
+
+	return response.DeletedResponse(c, nil)
+}
+
+func extractTableName(fullTableName string) string {
+	if idx := strings.Index(fullTableName, "."); idx != -1 {
+		return fullTableName[idx+1:]
+	}
+
+	return fullTableName
+}

--- a/internal/api/mapper/webhook.go
+++ b/internal/api/mapper/webhook.go
@@ -1,0 +1,27 @@
+package mapper
+
+import (
+	webhookDto "fluxend/internal/api/dto/webhook"
+	webhookDomain "fluxend/internal/domain/webhook"
+)
+
+func ToWebhookResponse(config *webhookDomain.Config) webhookDto.Response {
+	return webhookDto.Response{
+		Uuid:      config.Uuid,
+		TableName: config.TableName,
+		URL:       config.URL,
+		Events:    []string(config.Events),
+		IsActive:  config.IsActive,
+		CreatedAt: config.CreatedAt.Format("2006-01-02 15:04:05"),
+		UpdatedAt: config.UpdatedAt.Format("2006-01-02 15:04:05"),
+	}
+}
+
+func ToWebhookResourceCollection(configs []webhookDomain.Config) []webhookDto.Response {
+	responses := make([]webhookDto.Response, len(configs))
+	for i := range configs {
+		responses[i] = ToWebhookResponse(&configs[i])
+	}
+
+	return responses
+}

--- a/internal/api/routes/row.go
+++ b/internal/api/routes/row.go
@@ -1,0 +1,17 @@
+package routes
+
+import (
+	"fluxend/internal/api/handlers"
+	"github.com/labstack/echo/v4"
+	"github.com/samber/do"
+)
+
+func RegisterRowRoutes(e *echo.Echo, container *do.Injector, authMiddleware echo.MiddlewareFunc) {
+	rowController := do.MustInvoke[*handlers.RowHandler](container)
+
+	rowsGroup := e.Group("tables/:fullTableName/rows", authMiddleware)
+
+	rowsGroup.POST("", rowController.Insert)
+	rowsGroup.PATCH("", rowController.Update)
+	rowsGroup.DELETE("", rowController.Delete)
+}

--- a/internal/api/routes/webhook.go
+++ b/internal/api/routes/webhook.go
@@ -1,0 +1,17 @@
+package routes
+
+import (
+	"fluxend/internal/api/handlers"
+	"github.com/labstack/echo/v4"
+	"github.com/samber/do"
+)
+
+func RegisterWebhookRoutes(e *echo.Echo, container *do.Injector, authMiddleware echo.MiddlewareFunc) {
+	webhookController := do.MustInvoke[*handlers.WebhookHandler](container)
+
+	webhooksGroup := e.Group("tables/:fullTableName/webhooks", authMiddleware)
+
+	webhooksGroup.GET("", webhookController.List)
+	webhooksGroup.POST("", webhookController.Store)
+	webhooksGroup.DELETE("/:webhookUUID", webhookController.Delete)
+}

--- a/internal/app/commands/server.go
+++ b/internal/app/commands/server.go
@@ -110,6 +110,8 @@ func registerRoutes(e *echo.Echo, container *do.Injector) {
 	routes.RegisterOrganizationRoutes(e, container, authMiddleware)
 	routes.RegisterProjectRoutes(e, container, authMiddleware, allowProjectMiddleware)
 	routes.RegisterTableRoutes(e, container, authMiddleware)
+	routes.RegisterRowRoutes(e, container, authMiddleware)
+	routes.RegisterWebhookRoutes(e, container, authMiddleware)
 	routes.RegisterFormRoutes(e, container, authMiddleware, allowFormMiddleware)
 	routes.RegisterStorageRoutes(e, container, authMiddleware, allowStorageMiddleware)
 	routes.RegisterFunctionRoutes(e, container, authMiddleware)

--- a/internal/app/container.go
+++ b/internal/app/container.go
@@ -24,6 +24,7 @@ import (
 	"fluxend/internal/domain/storage/container"
 	"fluxend/internal/domain/storage/file"
 	"fluxend/internal/domain/user"
+	"fluxend/internal/domain/webhook"
 	"github.com/jmoiron/sqlx"
 	"github.com/samber/do"
 )
@@ -118,6 +119,13 @@ func InitializeContainer() *do.Injector {
 	do.Provide(injector, handlers.NewColumnHandler)
 	do.Provide(injector, handlers.NewIndexHandler)
 	do.Provide(injector, handlers.NewFunctionHandler)
+
+	// --- Webhooks ---
+	do.Provide(injector, repositories.NewWebhookRepository)
+	do.Provide(injector, webhook.NewWebhookPolicy)
+	do.Provide(injector, webhook.NewWebhookService)
+	do.Provide(injector, handlers.NewWebhookHandler)
+	do.Provide(injector, handlers.NewRowHandler)
 
 	// --- Health ---
 	do.Provide(injector, health.NewHealthService)

--- a/internal/database/migrations/20260626000001_add_webhook_configs_table.sql
+++ b/internal/database/migrations/20260626000001_add_webhook_configs_table.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+CREATE TABLE fluxend.webhook_configs (
+    uuid UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_uuid UUID NOT NULL,
+    table_name VARCHAR(255) NOT NULL,
+    url TEXT NOT NULL,
+    events TEXT[] NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_by UUID REFERENCES authentication.users(uuid),
+    updated_by UUID REFERENCES authentication.users(uuid),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    CONSTRAINT fk_webhook_configs_project FOREIGN KEY (project_uuid)
+        REFERENCES fluxend.projects(uuid) ON DELETE CASCADE
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS fluxend.webhook_configs CASCADE;

--- a/internal/database/repositories/webhook.go
+++ b/internal/database/repositories/webhook.go
@@ -1,0 +1,99 @@
+package repositories
+
+import (
+	"fluxend/internal/domain/shared"
+	"fluxend/internal/domain/webhook"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/samber/do"
+)
+
+type WebhookRepository struct {
+	db shared.DB
+}
+
+func NewWebhookRepository(injector *do.Injector) (webhook.Repository, error) {
+	db := do.MustInvoke[shared.DB](injector)
+	return &WebhookRepository{db: db}, nil
+}
+
+func (r *WebhookRepository) ListForTable(projectUUID uuid.UUID, tableName string) ([]webhook.Config, error) {
+	query := `
+		SELECT uuid, project_uuid, table_name, url, events, is_active, created_by, updated_by, created_at, updated_at
+		FROM fluxend.webhook_configs
+		WHERE project_uuid = $1 AND table_name = $2
+		ORDER BY created_at DESC
+	`
+
+	var configs []webhook.Config
+	if err := r.db.Select(&configs, query, projectUUID, tableName); err != nil {
+		return nil, err
+	}
+
+	return configs, nil
+}
+
+func (r *WebhookRepository) ListActiveForTableAndEvent(projectUUID uuid.UUID, tableName, event string) ([]webhook.Config, error) {
+	query := `
+		SELECT uuid, project_uuid, table_name, url, events, is_active, created_by, updated_by, created_at, updated_at
+		FROM fluxend.webhook_configs
+		WHERE project_uuid = $1 AND table_name = $2 AND is_active = TRUE AND $3 = ANY(events)
+	`
+
+	var configs []webhook.Config
+	if err := r.db.Select(&configs, query, projectUUID, tableName, event); err != nil {
+		return nil, err
+	}
+
+	return configs, nil
+}
+
+func (r *WebhookRepository) GetByUUID(webhookUUID uuid.UUID) (webhook.Config, error) {
+	query := `
+		SELECT uuid, project_uuid, table_name, url, events, is_active, created_by, updated_by, created_at, updated_at
+		FROM fluxend.webhook_configs
+		WHERE uuid = $1
+	`
+
+	var config webhook.Config
+	return config, r.db.GetWithNotFound(&config, "webhook.error.notFound", query, webhookUUID)
+}
+
+func (r *WebhookRepository) ExistsByUUID(webhookUUID uuid.UUID) (bool, error) {
+	return r.db.Exists("fluxend.webhook_configs", "uuid = $1", webhookUUID)
+}
+
+func (r *WebhookRepository) Create(config *webhook.Config) (*webhook.Config, error) {
+	return config, r.db.WithTransaction(func(tx shared.Tx) error {
+		query := `
+			INSERT INTO fluxend.webhook_configs (
+				project_uuid, table_name, url, events, is_active, created_by, updated_by
+			) VALUES (
+				$1, $2, $3, $4, $5, $6, $7
+			)
+			RETURNING uuid
+		`
+
+		return tx.QueryRowx(
+			query,
+			config.ProjectUuid,
+			config.TableName,
+			config.URL,
+			pq.Array(config.Events),
+			config.IsActive,
+			config.CreatedBy,
+			config.UpdatedBy,
+		).Scan(&config.Uuid)
+	})
+}
+
+func (r *WebhookRepository) Delete(webhookUUID uuid.UUID) (bool, error) {
+	rowsAffected, err := r.db.ExecWithRowsAffected(
+		"DELETE FROM fluxend.webhook_configs WHERE uuid = $1", webhookUUID,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	return rowsAffected == 1, nil
+}

--- a/internal/domain/webhook/entity.go
+++ b/internal/domain/webhook/entity.go
@@ -1,0 +1,28 @@
+package webhook
+
+import (
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"time"
+)
+
+type Config struct {
+	Uuid        uuid.UUID      `db:"uuid"`
+	ProjectUuid uuid.UUID      `db:"project_uuid"`
+	TableName   string         `db:"table_name"`
+	URL         string         `db:"url"`
+	Events      pq.StringArray `db:"events"`
+	IsActive    bool           `db:"is_active"`
+	CreatedBy   uuid.UUID      `db:"created_by"`
+	UpdatedBy   uuid.UUID      `db:"updated_by"`
+	CreatedAt   time.Time      `db:"created_at"`
+	UpdatedAt   time.Time      `db:"updated_at"`
+}
+
+type Payload struct {
+	Event     string      `json:"event"`
+	Table     string      `json:"table"`
+	Project   string      `json:"project"`
+	Timestamp string      `json:"timestamp"`
+	Record    interface{} `json:"record"`
+}

--- a/internal/domain/webhook/policy.go
+++ b/internal/domain/webhook/policy.go
@@ -1,0 +1,53 @@
+package webhook
+
+import (
+	"fluxend/internal/domain/auth"
+	"fluxend/internal/domain/organization"
+	"github.com/google/uuid"
+	"github.com/samber/do"
+)
+
+type Policy struct {
+	organizationRepo organization.Repository
+}
+
+func NewWebhookPolicy(injector *do.Injector) (*Policy, error) {
+	repo := do.MustInvoke[organization.Repository](injector)
+
+	return &Policy{organizationRepo: repo}, nil
+}
+
+func (p *Policy) CanAccess(organizationUUID uuid.UUID, authUser auth.User) bool {
+	isMember, err := p.organizationRepo.IsOrganizationMember(organizationUUID, authUser.Uuid)
+	if err != nil {
+		return false
+	}
+
+	return isMember
+}
+
+func (p *Policy) CanCreate(organizationUUID uuid.UUID, authUser auth.User) bool {
+	if !authUser.IsDeveloperOrMore() {
+		return false
+	}
+
+	isMember, err := p.organizationRepo.IsOrganizationMember(organizationUUID, authUser.Uuid)
+	if err != nil {
+		return false
+	}
+
+	return isMember
+}
+
+func (p *Policy) CanDelete(organizationUUID uuid.UUID, authUser auth.User) bool {
+	if !authUser.IsDeveloperOrMore() {
+		return false
+	}
+
+	isMember, err := p.organizationRepo.IsOrganizationMember(organizationUUID, authUser.Uuid)
+	if err != nil {
+		return false
+	}
+
+	return isMember
+}

--- a/internal/domain/webhook/repository.go
+++ b/internal/domain/webhook/repository.go
@@ -1,0 +1,12 @@
+package webhook
+
+import "github.com/google/uuid"
+
+type Repository interface {
+	ListForTable(projectUUID uuid.UUID, tableName string) ([]Config, error)
+	ListActiveForTableAndEvent(projectUUID uuid.UUID, tableName, event string) ([]Config, error)
+	GetByUUID(webhookUUID uuid.UUID) (Config, error)
+	ExistsByUUID(webhookUUID uuid.UUID) (bool, error)
+	Create(config *Config) (*Config, error)
+	Delete(webhookUUID uuid.UUID) (bool, error)
+}

--- a/internal/domain/webhook/service.go
+++ b/internal/domain/webhook/service.go
@@ -1,0 +1,165 @@
+package webhook
+
+import (
+	"bytes"
+	"encoding/json"
+	"fluxend/internal/domain/auth"
+	"fluxend/internal/domain/project"
+	"fluxend/pkg/errors"
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/rs/zerolog/log"
+	"github.com/samber/do"
+	"net/http"
+	"time"
+)
+
+type Service interface {
+	List(projectUUID uuid.UUID, tableName string, authUser auth.User) ([]Config, error)
+	Create(input CreateInput, authUser auth.User) (Config, error)
+	Delete(webhookUUID uuid.UUID, authUser auth.User) (bool, error)
+	Fire(projectUUID uuid.UUID, tableName, event string, record interface{})
+}
+
+type CreateInput struct {
+	ProjectUUID uuid.UUID
+	TableName   string
+	URL         string
+	Events      []string
+	IsActive    bool
+}
+
+type ServiceImpl struct {
+	policy      *Policy
+	webhookRepo Repository
+	projectRepo project.Repository
+	httpClient  *http.Client
+}
+
+func NewWebhookService(injector *do.Injector) (Service, error) {
+	policy := do.MustInvoke[*Policy](injector)
+	webhookRepo := do.MustInvoke[Repository](injector)
+	projectRepo := do.MustInvoke[project.Repository](injector)
+
+	return &ServiceImpl{
+		policy:      policy,
+		webhookRepo: webhookRepo,
+		projectRepo: projectRepo,
+		httpClient:  &http.Client{Timeout: 10 * time.Second},
+	}, nil
+}
+
+func (s *ServiceImpl) List(projectUUID uuid.UUID, tableName string, authUser auth.User) ([]Config, error) {
+	organizationUUID, err := s.projectRepo.GetOrganizationUUIDByProjectUUID(projectUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	if !s.policy.CanAccess(organizationUUID, authUser) {
+		return nil, errors.NewForbiddenError("webhook.error.listForbidden")
+	}
+
+	return s.webhookRepo.ListForTable(projectUUID, tableName)
+}
+
+func (s *ServiceImpl) Create(input CreateInput, authUser auth.User) (Config, error) {
+	organizationUUID, err := s.projectRepo.GetOrganizationUUIDByProjectUUID(input.ProjectUUID)
+	if err != nil {
+		return Config{}, err
+	}
+
+	if !s.policy.CanCreate(organizationUUID, authUser) {
+		return Config{}, errors.NewForbiddenError("webhook.error.createForbidden")
+	}
+
+	config := Config{
+		ProjectUuid: input.ProjectUUID,
+		TableName:   input.TableName,
+		URL:         input.URL,
+		Events:      pq.StringArray(input.Events),
+		IsActive:    input.IsActive,
+		CreatedBy:   authUser.Uuid,
+		UpdatedBy:   authUser.Uuid,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+
+	_, err = s.webhookRepo.Create(&config)
+	if err != nil {
+		return Config{}, err
+	}
+
+	return config, nil
+}
+
+func (s *ServiceImpl) Delete(webhookUUID uuid.UUID, authUser auth.User) (bool, error) {
+	fetched, err := s.webhookRepo.GetByUUID(webhookUUID)
+	if err != nil {
+		return false, err
+	}
+
+	organizationUUID, err := s.projectRepo.GetOrganizationUUIDByProjectUUID(fetched.ProjectUuid)
+	if err != nil {
+		return false, err
+	}
+
+	if !s.policy.CanDelete(organizationUUID, authUser) {
+		return false, errors.NewForbiddenError("webhook.error.deleteForbidden")
+	}
+
+	return s.webhookRepo.Delete(webhookUUID)
+}
+
+func (s *ServiceImpl) Fire(projectUUID uuid.UUID, tableName, event string, record interface{}) {
+	webhooks, err := s.webhookRepo.ListActiveForTableAndEvent(projectUUID, tableName, event)
+	if err != nil || len(webhooks) == 0 {
+		return
+	}
+
+	payload := Payload{
+		Event:     event,
+		Table:     tableName,
+		Project:   projectUUID.String(),
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Record:    record,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		log.Error().Str("table", tableName).Str("event", event).Msg("webhook: failed to marshal payload")
+		return
+	}
+
+	for _, wh := range webhooks {
+		if err := s.post(wh.URL, body); err != nil {
+			log.Error().
+				Str("url", wh.URL).
+				Str("table", tableName).
+				Str("event", event).
+				Str("error", err.Error()).
+				Msg("webhook: delivery failed")
+		}
+	}
+}
+
+func (s *ServiceImpl) post(url string, body []byte) error {
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("non-2xx status: %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/web/app/routes.ts
+++ b/web/app/routes.ts
@@ -25,6 +25,7 @@ export default [
       ]),
       route("tables/create", "./routes/tables/create.tsx"),
       route("tables/:tableId/edit", "./routes/tables/edit.tsx"),
+      route("tables/:tableId/webhooks", "./routes/tables/webhooks.tsx"),
       route("tables", "./routes/tables/sidebar.tsx", [
         route(":tableId", "./routes/tables/page.tsx"),
       ]),

--- a/web/app/routes/tables/page.tsx
+++ b/web/app/routes/tables/page.tsx
@@ -27,7 +27,7 @@ export function meta({}: Route.MetaArgs) {
   ];
 }
 import { Button } from "~/components/ui/button";
-import { Trash2, Pencil, FileText } from "lucide-react";
+import { Trash2, Pencil, FileText, Webhook } from "lucide-react";
 import { toast } from "sonner";
 import type { TableRow, CellValue } from "~/types/table";
 
@@ -63,29 +63,21 @@ export default function TablePageContent({ params }: Route.ComponentProps) {
   } = useQuery(columnsQuery(projectId, tableId)) || { data: [] };
 
   const handleCellUpdate = useCallback(async (
-    rowId: string, 
-    columnName: string, 
+    rowId: string,
+    columnName: string,
     value: CellValue,
     rowData: TableRow
   ): Promise<boolean> => {
     try {
-      // Only send the field that changed
       const updateData = {
         [columnName]: value
       };
-      
-      const baseDomain = import.meta.env.VITE_FLX_BASE_DOMAIN;
-      const httpScheme = import.meta.env.VITE_FLX_HTTP_SCHEME;
-      const baseUrl = `${httpScheme}://${projectDetails?.dbName}.${baseDomain}/`;
-      
+
       const response = await services.tables.updateTableRow(
         projectId,
         tableId,
         rowId,
         updateData,
-        {
-          baseUrl,
-        }
       );
 
       if (response.ok) {
@@ -111,7 +103,7 @@ export default function TablePageContent({ params }: Route.ComponentProps) {
       // Return false to trigger revert in OptimisticTableCell
       return false;
     }
-  }, [projectId, tableId, services.tables, projectDetails?.dbName]);
+  }, [projectId, tableId, services.tables]);
 
   const columns = useMemo(() => {
     if (!columnsData || !Array.isArray(columnsData)) {
@@ -231,7 +223,7 @@ export default function TablePageContent({ params }: Route.ComponentProps) {
   }, [tableId, projectId, queryClient, navigate]);
 
   const handleBulkDelete = useCallback(async () => {
-    if (!tableId || !projectId || !projectDetails?.dbName || selectedRows.length === 0) return;
+    if (!tableId || !projectId || selectedRows.length === 0) return;
 
     const rowIds = selectedRows.map(row => row.id).filter(Boolean);
     if (rowIds.length === 0) {
@@ -240,19 +232,12 @@ export default function TablePageContent({ params }: Route.ComponentProps) {
     }
 
     setIsDeletingRows(true);
-    
-    try {
-      const baseDomain = import.meta.env.VITE_FLX_BASE_DOMAIN;
-      const httpScheme = import.meta.env.VITE_FLX_HTTP_SCHEME;
-      const baseUrl = `${httpScheme}://${projectDetails.dbName}.${baseDomain}/`;
 
+    try {
       const response = await services.tables.deleteTableRows(
         projectId,
         tableId,
         rowIds,
-        {
-          baseUrl,
-        }
       );
 
       if (response.ok) {
@@ -289,7 +274,7 @@ export default function TablePageContent({ params }: Route.ComponentProps) {
     } finally {
       setIsDeletingRows(false);
     }
-  }, [tableId, projectId, projectDetails?.dbName, queryClient, pagination, filterParams, services.tables, selectedRows]);
+  }, [tableId, projectId, queryClient, pagination, filterParams, services.tables, selectedRows]);
 
   const noTableSelected = !tableId;
 
@@ -401,6 +386,16 @@ export default function TablePageContent({ params }: Route.ComponentProps) {
                   title="View API Docs"
                 >
                   <FileText />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="cursor-pointer"
+                  onClick={() => navigate(`/projects/${projectId}/tables/${tableId}/webhooks`)}
+                  title="Webhooks"
+                >
+                  <Webhook />
                 </Button>
                 <Button
                   type="button"

--- a/web/app/routes/tables/webhooks.tsx
+++ b/web/app/routes/tables/webhooks.tsx
@@ -1,0 +1,281 @@
+import { useState } from "react";
+import { useParams, useOutletContext } from "react-router";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Trash2, Webhook, Plus } from "lucide-react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import type { ProjectLayoutOutletContext } from "~/components/shared/project-layout";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Badge } from "~/components/ui/badge";
+import { Checkbox } from "~/components/ui/checkbox";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "~/components/ui/form";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "~/components/ui/alert-dialog";
+import type { APIResponse } from "~/lib/types";
+import type { Webhook as WebhookType } from "~/services/webhooks";
+
+const EVENT_OPTIONS = [
+  { value: "insert", label: "Insert" },
+  { value: "update", label: "Update" },
+  { value: "delete", label: "Delete" },
+] as const;
+
+const createWebhookSchema = z.object({
+  url: z.string().url("Must be a valid URL"),
+  events: z.array(z.string()).min(1, "Select at least one event"),
+  is_active: z.boolean(),
+});
+
+type CreateWebhookForm = z.infer<typeof createWebhookSchema>;
+
+export function meta() {
+  return [{ title: "Webhooks - Fluxend" }];
+}
+
+export default function WebhooksPage() {
+  const { projectId, tableId } = useParams();
+  const { services } = useOutletContext<ProjectLayoutOutletContext>();
+  const queryClient = useQueryClient();
+  const [showForm, setShowForm] = useState(false);
+
+  const form = useForm<CreateWebhookForm>({
+    resolver: zodResolver(createWebhookSchema),
+    defaultValues: { url: "", events: [], is_active: true },
+  });
+
+  const { data: webhooks = [], isLoading } = useQuery<WebhookType[]>({
+    queryKey: ["webhooks", projectId, tableId],
+    queryFn: async () => {
+      const response = await services.webhooks.listWebhooks(projectId!, tableId!);
+      const data = (await response.json()) as APIResponse<WebhookType[]>;
+      return data.content ?? [];
+    },
+    enabled: !!projectId && !!tableId,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: async (values: CreateWebhookForm) => {
+      const response = await services.webhooks.createWebhook(
+        projectId!,
+        tableId!,
+        values
+      );
+      const data = (await response.json()) as APIResponse<WebhookType>;
+      if (!response.ok) {
+        throw new Error(data.errors?.[0] ?? "Failed to create webhook");
+      }
+      return data.content;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["webhooks", projectId, tableId] });
+      toast.success("Webhook created");
+      form.reset();
+      setShowForm(false);
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (webhookUUID: string) => {
+      const response = await services.webhooks.deleteWebhook(
+        projectId!,
+        tableId!,
+        webhookUUID
+      );
+      if (!response.ok) {
+        throw new Error("Failed to delete webhook");
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["webhooks", projectId, tableId] });
+      toast.success("Webhook deleted");
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  const onSubmit = (values: CreateWebhookForm) => createMutation.mutate(values);
+
+  return (
+    <div className="flex flex-col h-full overflow-auto">
+      <div className="border-b px-4 py-2 mb-4 flex-shrink-0">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Webhook className="size-4" />
+            <span className="text-base font-bold">
+              Webhooks / {tableId}
+            </span>
+          </div>
+          <Button size="sm" onClick={() => setShowForm((v) => !v)}>
+            <Plus className="size-4 mr-1" />
+            Add Webhook
+          </Button>
+        </div>
+      </div>
+
+      <div className="px-4 space-y-4">
+        {showForm && (
+          <div className="border rounded-lg p-4 bg-muted/10">
+            <h3 className="text-sm font-semibold mb-3">New Webhook</h3>
+            <Form {...form}>
+              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                <FormField
+                  control={form.control}
+                  name="url"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Endpoint URL</FormLabel>
+                      <FormControl>
+                        <Input placeholder="https://example.com/webhook" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="events"
+                  render={() => (
+                    <FormItem>
+                      <FormLabel>Events</FormLabel>
+                      <div className="flex gap-4">
+                        {EVENT_OPTIONS.map((opt) => (
+                          <FormField
+                            key={opt.value}
+                            control={form.control}
+                            name="events"
+                            render={({ field }) => (
+                              <FormItem className="flex items-center gap-2">
+                                <FormControl>
+                                  <Checkbox
+                                    checked={field.value.includes(opt.value)}
+                                    onCheckedChange={(checked) => {
+                                      if (checked) {
+                                        field.onChange([...field.value, opt.value]);
+                                      } else {
+                                        field.onChange(
+                                          field.value.filter((v) => v !== opt.value)
+                                        );
+                                      }
+                                    }}
+                                  />
+                                </FormControl>
+                                <FormLabel className="font-normal cursor-pointer">
+                                  {opt.label}
+                                </FormLabel>
+                              </FormItem>
+                            )}
+                          />
+                        ))}
+                      </div>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <div className="flex gap-2">
+                  <Button
+                    type="submit"
+                    size="sm"
+                    disabled={createMutation.isPending}
+                  >
+                    {createMutation.isPending ? "Saving..." : "Save"}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => { setShowForm(false); form.reset(); }}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </form>
+            </Form>
+          </div>
+        )}
+
+        {isLoading && (
+          <div className="text-sm text-muted-foreground">Loading webhooks...</div>
+        )}
+
+        {!isLoading && webhooks.length === 0 && !showForm && (
+          <div className="flex items-center justify-center border rounded-lg p-8 bg-muted/10">
+            <div className="text-center text-muted-foreground">
+              <Webhook className="size-8 mx-auto mb-2 opacity-40" />
+              <p className="text-sm">No webhooks configured for this table.</p>
+            </div>
+          </div>
+        )}
+
+        {webhooks.map((wh) => (
+          <div
+            key={wh.uuid}
+            className="flex items-center justify-between border rounded-lg px-4 py-3 bg-background"
+          >
+            <div className="flex flex-col gap-1 min-w-0">
+              <span className="text-sm font-medium truncate">{wh.url}</span>
+              <div className="flex gap-1 flex-wrap">
+                {wh.events.map((ev) => (
+                  <Badge key={ev} variant="secondary" className="text-xs capitalize">
+                    {ev}
+                  </Badge>
+                ))}
+                {!wh.isActive && (
+                  <Badge variant="outline" className="text-xs text-muted-foreground">
+                    inactive
+                  </Badge>
+                )}
+              </div>
+            </div>
+
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="ghost" size="icon" className="shrink-0 ml-2">
+                  <Trash2 className="size-4" />
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete webhook?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will permanently remove the webhook endpoint{" "}
+                    <strong>{wh.url}</strong>. No further deliveries will be made.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() => deleteMutation.mutate(wh.uuid)}
+                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  >
+                    Delete
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/app/services/index.ts
+++ b/web/app/services/index.ts
@@ -6,6 +6,7 @@ import { createUserService } from "./user";
 import { createLogsService } from "./logs";
 import { createSettingsService } from "./settings";
 import { createStorageService } from "./storage";
+import { createWebhooksService } from "./webhooks";
 
 export function initializeServices(authToken: string) {
   return {
@@ -17,6 +18,7 @@ export function initializeServices(authToken: string) {
     logs: createLogsService(authToken),
     settings: createSettingsService(authToken),
     storage: createStorageService(authToken),
+    webhooks: createWebhooksService(authToken),
   };
 }
 

--- a/web/app/services/tables.ts
+++ b/web/app/services/tables.ts
@@ -104,52 +104,55 @@ export function createTablesService(authToken: string) {
     return patch(`/tables/public.${tableName}/columns`, data, fetchOptions);
   };
 
+  const createTableRow = async (projectId: string, tableId: string, data: any) => {
+    const fetchOptions: APIRequestOptions = {
+      headers: {
+        "X-Project": projectId,
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${authToken}`,
+        "Prefer": "return=representation",
+      },
+    };
+
+    return post(`/tables/public.${tableId}/rows`, data, fetchOptions);
+  };
+
   const updateTableRow = async (
-    projectId: string, 
-    tableId: string, 
-    rowId: string, 
+    projectId: string,
+    tableId: string,
+    rowId: string,
     data: any,
-    options?: {
-      baseUrl?: string;
-    }
   ) => {
     const fetchOptions: APIRequestOptions = {
       headers: {
         "X-Project": projectId,
         "Content-Type": "application/json",
         Authorization: `Bearer ${authToken}`,
-        "Prefer": "return=representation", // Return the updated row
+        "Prefer": "return=representation",
       },
-      baseUrl: options?.baseUrl,
       params: {
-        id: `eq.${rowId}` // PostgREST filter syntax
-      }
+        id: `eq.${rowId}`,
+      },
     };
 
-    return patch(tableId, data, fetchOptions);
+    return patch(`/tables/public.${tableId}/rows`, data, fetchOptions);
   };
 
   const deleteTableRows = async (
     projectId: string,
     tableId: string,
     rowIds: string[],
-    options?: {
-      baseUrl?: string;
-    }
   ) => {
-    // Validate input
     if (!rowIds || rowIds.length === 0) {
-      throw new Error('No row IDs provided for deletion');
+      throw new Error("No row IDs provided for deletion");
     }
 
-    // Escape IDs to prevent injection
-    const escapedIds = rowIds.map(id => 
-      // Remove any special characters that could break the query
-      String(id).replace(/[^a-zA-Z0-9-_]/g, '')
-    ).filter(Boolean);
+    const escapedIds = rowIds
+      .map((id) => String(id).replace(/[^a-zA-Z0-9-_]/g, ""))
+      .filter(Boolean);
 
     if (escapedIds.length === 0) {
-      throw new Error('No valid row IDs provided for deletion');
+      throw new Error("No valid row IDs provided for deletion");
     }
 
     const fetchOptions: APIRequestOptions = {
@@ -157,15 +160,14 @@ export function createTablesService(authToken: string) {
         "X-Project": projectId,
         "Content-Type": "application/json",
         Authorization: `Bearer ${authToken}`,
-        "Prefer": "count=exact", // Return count of deleted rows
+        "Prefer": "return=representation",
       },
-      baseUrl: options?.baseUrl,
       params: {
-        id: `in.(${escapedIds.join(",")})` // PostgREST filter syntax for multiple IDs
-      }
+        id: `in.(${escapedIds.join(",")})`,
+      },
     };
 
-    return del(tableId, fetchOptions);
+    return del(`/tables/public.${tableId}/rows`, fetchOptions);
   };
 
   return {
@@ -176,6 +178,7 @@ export function createTablesService(authToken: string) {
     deleteTable,
     createTableColumns,
     updateTableColumns,
+    createTableRow,
     updateTableRow,
     deleteTableRows,
   };

--- a/web/app/services/webhooks.ts
+++ b/web/app/services/webhooks.ts
@@ -1,0 +1,70 @@
+import { get, post, del } from "~/tools/fetch";
+
+export interface Webhook {
+  uuid: string;
+  tableName: string;
+  url: string;
+  events: string[];
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateWebhookDto {
+  url: string;
+  events: string[];
+  is_active: boolean;
+}
+
+export function createWebhooksService(authToken: string) {
+  const listWebhooks = async (projectId: string, tableName: string) => {
+    const fetchOptions: RequestInit = {
+      headers: {
+        "X-Project": projectId,
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${authToken}`,
+      },
+    };
+
+    return get(`/tables/public.${tableName}/webhooks`, fetchOptions);
+  };
+
+  const createWebhook = async (
+    projectId: string,
+    tableName: string,
+    data: CreateWebhookDto
+  ) => {
+    const fetchOptions: RequestInit = {
+      headers: {
+        "X-Project": projectId,
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${authToken}`,
+      },
+    };
+
+    return post(`/tables/public.${tableName}/webhooks`, data, fetchOptions);
+  };
+
+  const deleteWebhook = async (
+    projectId: string,
+    tableName: string,
+    webhookUUID: string
+  ) => {
+    const fetchOptions: RequestInit = {
+      headers: {
+        "X-Project": projectId,
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${authToken}`,
+      },
+    };
+
+    return del(
+      `/tables/public.${tableName}/webhooks/${webhookUUID}`,
+      fetchOptions
+    );
+  };
+
+  return { listWebhooks, createWebhook, deleteWebhook };
+}
+
+export type WebhooksService = ReturnType<typeof createWebhooksService>;


### PR DESCRIPTION
## What

Implements HTTP webhooks fired synchronously when rows are inserted, updated, or deleted via the Fluxend API. Users configure webhook endpoints per table through a new UI; the platform POSTs the row payload and event metadata to each active endpoint on every mutation.

## Changes

- Add `fluxend.webhook_configs` migration (url, events TEXT[], is_active, project FK cascade)
- Add `webhook` domain package: entity, repository interface, policy, service with synchronous HTTP Fire
- Add `WebhookRepository` with `pq.StringArray` for events and `ANY(events)` filter query
- Add row proxy handler: forwards INSERT/UPDATE/DELETE to PostgREST internally (`http://postgrest_{dbName}:3000/`), captures response rows, fires webhooks
- Add webhook config handler (List/Store/Delete) under `/tables/:fullTableName/webhooks`
- Register new routes and DI bindings
- Route frontend row mutations through Fluxend API instead of PostgREST directly
- Add webhooks service and webhooks page with list/add/delete UI; Webhook icon in table toolbar

## Test plan

- [ ] Run migration and confirm `fluxend.webhook_configs` table exists
- [ ] Add a webhook via UI pointing to webhook.site with all three event types
- [ ] Insert a row via the table UI — confirm payload arrives at webhook.site with correct `event`, `table`, `project`, `timestamp`, and `record`
- [ ] Update a row — confirm `update` event fires with the updated row
- [ ] Delete a row — confirm `delete` event fires with the deleted row data
- [ ] Create a webhook with `is_active: false` — confirm no deliveries are made
- [ ] Delete a webhook config — confirm it disappears from the list and no further deliveries
- [ ] Confirm row reads (GET) still go directly to PostgREST (no regression)