### PR TITLE
[feat] [FLX-159] per-project JWT signing secrets for PostgREST

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <strong>Open source, self-hosted Backend-as-a-Service built with Go.</strong><br>
-  Instant REST APIs, auth, file storage, forms, and audit logs — all over your own PostgreSQL database.
+  Instant REST APIs, auth, file storage, forms, and audit logs. All on your own PostgreSQL database.
 </p>
 
 <p align="center">
@@ -30,11 +30,11 @@
 
 ## What is Fluxend?
 
-Fluxend is a **self-hosted, open source Backend-as-a-Service (BaaS)**. It gives you the developer experience of Firebase or Supabase — instant APIs, authentication, file storage — while keeping your data on infrastructure you control.
+Fluxend is a self-hosted, open source Backend-as-a-Service (BaaS). It gives you the developer experience of Firebase or Supabase: instant APIs, authentication, and file storage. Your data stays on infrastructure you control.
 
-You define your database tables through the UI or API. Fluxend generates fully functional REST endpoints for them automatically, backed by PostgreSQL and served through PostgREST. No code generation. No lock-in. No monthly seat fees.
+You define your database tables through the UI or API. Fluxend generates fully functional REST endpoints automatically, backed by PostgreSQL and served through PostgREST. No code generation. No lock-in. No monthly seat fees.
 
-**Built with:** Go 1.23 · Echo · PostgreSQL 17 · PostgREST · Docker · React 19 · TypeScript
+Go 1.23 · Echo · PostgreSQL 17 · PostgREST · Docker · React 19 · TypeScript
 
 ---
 
@@ -60,47 +60,47 @@ You define your database tables through the UI or API. Fluxend generates fully f
 ## Features
 
 ### Authentication and Access Control
-- **JWT authentication** — login, registration, token invalidation, session limits
-- **Organizations and RBAC** — multi-tenant support with Owner, Admin, Developer, and Explorer roles
-- **Per-project JWT secrets** — each project gets its own cryptographic signing secret; a token from one project is rejected by another
-- **Row-level security** — access control enforced at the database level via PostgreSQL roles
+- JWT authentication with login, registration, token invalidation, and session limits
+- Organizations with four roles: Owner, Admin, Developer, and Explorer
+- Per-project JWT secrets. Each project gets its own signing secret; a token from one project is rejected by another
+- Row-level security enforced at the database level through PostgreSQL roles
 
 ### Database and REST APIs
-- **Instant REST APIs** — create a table, get full CRUD endpoints immediately via PostgREST
-- **Schema management** — create, rename, and delete tables and columns through the API or UI
-- **Index management** — add and remove database indexes without writing SQL
-- **Stored functions** — define and call PostgreSQL functions through a REST interface
-- **CSV and XLSX import** — upload a spreadsheet, Fluxend creates the table and API for you
-- **Table duplication** — clone an existing table structure in one call
-- **OpenAPI export** — auto-generated OpenAPI documentation for every project
+- Instant REST APIs. Create a table, get full CRUD endpoints immediately through PostgREST
+- Schema management: create, rename, and delete tables and columns through the API or UI
+- Index management without writing SQL
+- Stored functions: define and call PostgreSQL functions through a REST interface
+- CSV and XLSX import. Upload a spreadsheet; Fluxend creates the table and API for you
+- Table duplication in one call
+- Auto-generated OpenAPI documentation for every project
 
 ### Storage
-- **Multi-driver file storage** — S3, Backblaze B2, Dropbox, or local filesystem
-- **File containers** — organize files into named buckets
-- **Download endpoints** — serve files through the API with access control
-- **Database backups** — scheduled or on-demand PostgreSQL backups per project
+- File storage with four drivers: S3, Backblaze B2, Dropbox, or local filesystem
+- File containers to organize uploads into named buckets
+- Download endpoints with access control
+- PostgreSQL backups per project, on-demand or scheduled
 
 ### Forms
-- **Smart forms** — create forms with typed fields and validation rules
-- **Form responses** — collect and query submissions through the API
-- **Field types** — text, number, boolean, and more
+- Forms with typed fields and validation rules
+- Submissions collected and queryable through the API
+- Field types: text, number, boolean, and more
 
 ### Observability
-- **Audit logs** — every API request to PostgREST endpoints is logged with user, method, status, and timestamp
-- **Database statistics** — table sizes, row counts, and index usage per project
-- **Health endpoint** — check container and database status across all projects
+- Audit logs on every PostgREST request: user, method, status, and timestamp
+- Database statistics: table sizes, row counts, and index usage per project
+- Health endpoint to check container and database status across all projects
 
 ### Developer Experience
-- **Self-contained Docker deployment** — Traefik, PostgreSQL, API, and frontend in one `docker compose up`
-- **CLI commands** — restart PostgREST instances, run migrations, seed settings from the command line
-- **Sentry integration** — error tracking built in, opt-in via environment variable
-- **CORS configuration** — per-deployment origin allowlist
+- Single `docker compose up` deploys Traefik, PostgreSQL, the API, and the frontend together
+- CLI commands to restart PostgREST instances, run migrations, and seed settings
+- Sentry integration, opt-in via environment variable
+- Per-deployment CORS origin allowlist
 
 ---
 
 ## Quick Start
 
-**Requirements:** Docker, Docker Compose
+Requires Docker and Docker Compose.
 
 ```bash
 git clone https://github.com/fluxend/fluxend.git
@@ -191,25 +191,35 @@ Full API reference: [docs.fluxend.app](https://docs.fluxend.app)
 
 ## Use Cases
 
-**SaaS backends** — multi-tenant architecture with per-org projects and RBAC out of the box.
+**SaaS products**
 
-**Internal tools** — spin up a data API from an existing PostgreSQL schema in minutes, no backend code required.
+The multi-tenant org structure and per-project RBAC are ready from day one. No extra configuration needed.
 
-**Rapid prototyping** — go from idea to working API in under five minutes. Replace Fluxend with a custom service later if you need to; your data stays in Postgres.
+**Internal tools**
 
-**Data collection** — use the forms API to collect submissions from external sources without managing a backend.
+Point Fluxend at an existing PostgreSQL schema and get a working data API in minutes. No backend code needed.
 
-**Firebase or Supabase migration** — move off a vendor-hosted BaaS without rewriting your frontend. Fluxend speaks the same REST patterns.
+**Rapid prototyping**
+
+Go from idea to working API in under five minutes. Replace Fluxend with a custom service later if you outgrow it; your data stays in Postgres.
+
+**Data collection**
+
+Use the forms API to collect submissions from external sources without managing a backend.
+
+**Firebase or Supabase migration**
+
+Move off a vendor-hosted BaaS without rewriting your frontend. Fluxend speaks the same REST patterns.
 
 ---
 
 ## Tech Stack
 
-**Backend:** Go 1.23 · Echo v4 · sqlx · PostgreSQL 17 · PostgREST · samber/do (DI) · golang-jwt · AWS SDK v2 · zerolog · Sentry
+Backend: Go 1.23 · Echo v4 · sqlx · PostgreSQL 17 · PostgREST · samber/do (DI) · golang-jwt · AWS SDK v2 · zerolog · Sentry
 
-**Frontend:** React 19 · React Router 7 · TanStack Query · Tailwind CSS 4 · shadcn/ui · TypeScript
+Frontend: React 19 · React Router 7 · TanStack Query · Tailwind CSS 4 · shadcn/ui · TypeScript
 
-**Infrastructure:** Docker · Docker Compose · Traefik v2 · goose (migrations)
+Infrastructure: Docker · Docker Compose · Traefik v2 · goose (migrations)
 
 ---
 
@@ -231,7 +241,7 @@ go build ./cmd/...
 See [AGENTS.md](./AGENTS.md) for architecture notes and coding standards.
 
 - Check [open issues](https://github.com/fluxend/fluxend/issues) for things to work on
-- Open a PR — reviews are fast
+- Open a PR. Reviews are fast.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -188,15 +188,6 @@ Move off a vendor-hosted BaaS without rewriting your frontend. Fluxend speaks th
 
 ---
 
-## Tech Stack
-
-Backend: Go 1.23 · Echo v4 · sqlx · PostgreSQL 17 · PostgREST · samber/do (DI) · golang-jwt · AWS SDK v2 · zerolog · Sentry
-
-Frontend: React 19 · React Router 7 · TanStack Query · Tailwind CSS 4 · shadcn/ui · TypeScript
-
-Infrastructure: Docker · Docker Compose · Traefik v2 · goose (migrations)
-
----
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -142,27 +142,6 @@ Full API reference: [docs.fluxend.app](https://docs.fluxend.app)
 
 ---
 
-## Environment Variables
-
-| Variable | Description |
-|---|---|
-| `DATABASE_HOST` | PostgreSQL host |
-| `DATABASE_USER` | PostgreSQL user |
-| `DATABASE_PASSWORD` | PostgreSQL password |
-| `DATABASE_NAME` | PostgreSQL database name |
-| `JWT_SECRET` | Secret for signing console/auth tokens (min 32 chars) |
-| `BASE_DOMAIN` | Root domain for Traefik routing |
-| `URL_SCHEME` | `http` or `https` |
-| `POSTGREST_DB_USER` | PostgreSQL user for PostgREST connections |
-| `POSTGREST_DB_PASSWORD` | PostgreSQL password for PostgREST connections |
-| `POSTGREST_DB_HOST` | PostgreSQL host for PostgREST containers |
-| `POSTGREST_DEFAULT_SCHEMA` | Default schema exposed by PostgREST |
-| `POSTGREST_DEFAULT_ROLE` | Anonymous role for PostgREST |
-| `STORAGE_DRIVER` | `local`, `s3`, `backblaze`, or `dropbox` |
-| `CUSTOM_ORIGINS` | Comma-separated CORS allowed origins |
-| `SENTRY_DSN` | Optional Sentry DSN for error tracking |
-
----
 
 ## Use Cases
 

--- a/README.md
+++ b/README.md
@@ -1,50 +1,240 @@
-# ⚡️ Fluxend
-**Fluxend** is a **blazing-fast, self-hosted BaaS** built with Go — no lock-in. Ship production-grade backends with full control over your data
-<div align="center">
-  
-
-[🚀 **Demo**](https://console.fluxend.app/) • 
-[📚 **Documentation**](https://docs.fluxend.app/) • 
-[⚡ **Installation**](https://docs.fluxend.app/quickstart) • 
-[❓ **FAQ**](https://docs.fluxend.app/faq) • 
-[🔧 **Commands**](https://docs.fluxend.app/essentials/commands) • 
-[🛠️ **Troubleshooting**](https://docs.fluxend.app/essentials/troubleshooting)
-
-</div>
+<h1 align="center">⚡️ Fluxend</h1>
 
 <p align="center">
-  <img src="web/public/demo.gif" alt="Demo">
+  <strong>Open source, self-hosted Backend-as-a-Service built with Go.</strong><br>
+  Instant REST APIs, auth, file storage, forms, and audit logs — all over your own PostgreSQL database.
 </p>
 
-## 🔥 Features
+<p align="center">
+  <a href="https://github.com/fluxend/fluxend/actions"><img src="https://github.com/fluxend/fluxend/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/fluxend/fluxend/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-GPL--3.0-blue" alt="License"></a>
+  <img src="https://img.shields.io/badge/go-1.23-00ADD8?logo=go" alt="Go 1.23">
+  <img src="https://img.shields.io/badge/postgres-17-336791?logo=postgresql" alt="PostgreSQL 17">
+  <a href="https://hub.docker.com/u/fluxend"><img src="https://img.shields.io/badge/docker-ready-2496ED?logo=docker" alt="Docker"></a>
+  <a href="https://github.com/fluxend/fluxend/stargazers"><img src="https://img.shields.io/github/stars/fluxend/fluxend?style=social" alt="Stars"></a>
+</p>
 
-### Authentication & Access Control
-**🔐 Plug-and-Play Auth** — OAuth, JWT, Magic Links — pick your poison  
-**🧑‍💼 Org & Role Management** — Built-in multi-tenant support with fine-grained RBAC  
-**🧮 Row-Level Permissions** — Control access down to the individual row
+<p align="center">
+  <a href="https://console.fluxend.app/">🚀 Live Demo</a> •
+  <a href="https://docs.fluxend.app/">📚 Docs</a> •
+  <a href="https://docs.fluxend.app/quickstart">⚡ Quick Start</a> •
+  <a href="https://docs.fluxend.app/faq">❓ FAQ</a> •
+  <a href="https://github.com/fluxend/fluxend/issues">🐛 Issues</a>
+</p>
 
-### Database & APIs
-**🔄 Realtime Database** — Instant updates pushed to clients  
-**🔥 Dynamic REST APIs** — Define tables, get CRUD endpoints automagically  
-**📥 Import CSV/XLSX as APIs** — Upload a file → Get a full API. Done.
+<p align="center">
+  <img src="web/public/demo.gif" alt="Fluxend demo">
+</p>
 
-### Backend Logic
-**⚙️ DB Triggers & Hooks** — Run server-side logic without extra services  
-**🧾 Smart Forms** — Auto-generated forms with validations and logic  
-**📜 Audit Logs** — Every action tracked. No black boxes.
+---
 
-### Storage & Integrations
-**☁️ Multi-Driver Storage** — S3, Dropbox, Backblaze, or local FS — your call  
-**🔍 Built-in Search Engine** *(coming soon)* — Typesense/Sphinx powered indexing and search  
-**🔁 Zapier Integration** *(coming soon)* — Automate anything with Fluxend events
+## What is Fluxend?
 
-## 🤝 Want to Contribute?
-We're building the most badass backend tool in the open. If you:
-- Hate boilerplate
-- Love Go
-- Want to build the next-gen BaaS engine
-- Want influence in an early-stage rocket
+Fluxend is a **self-hosted, open source Backend-as-a-Service (BaaS)**. It gives you the developer experience of Firebase or Supabase — instant APIs, authentication, file storage — while keeping your data on infrastructure you control.
 
-Then you're in the right place.
-- 🛠 Check out [issues](https://github.com/fluxend/fluxend/issues)
-- 📬 Drop a PR. We'll review it FAST.
+You define your database tables through the UI or API. Fluxend generates fully functional REST endpoints for them automatically, backed by PostgreSQL and served through PostgREST. No code generation. No lock-in. No monthly seat fees.
+
+**Built with:** Go 1.23 · Echo · PostgreSQL 17 · PostgREST · Docker · React 19 · TypeScript
+
+---
+
+## Why Fluxend?
+
+| | Firebase | Supabase | Appwrite | PocketBase | **Fluxend** |
+|---|:---:|:---:|:---:|:---:|:---:|
+| Self-hosted | ✗ | ✓ | ✓ | ✓ | ✓ |
+| Open source | ✗ | ✓ | ✓ | ✓ | ✓ |
+| Built with Go | ✗ | ✗ | ✗ | ✓ | ✓ |
+| PostgreSQL native | ✗ | ✓ | ✗ | ✗ | ✓ |
+| Dynamic REST APIs | ✗ | ✓ | ✓ | ✓ | ✓ |
+| CSV/XLSX import to API | ✗ | ✗ | ✗ | ✗ | ✓ |
+| Multi-tenant orgs + RBAC | limited | ✓ | ✓ | ✗ | ✓ |
+| Per-project JWT isolation | ✗ | ✓ | ✗ | ✗ | ✓ |
+| S3-compatible storage | ✗ | ✓ | ✓ | ✗ | ✓ |
+| Audit logs | ✗ | ✗ | ✓ | ✗ | ✓ |
+| Smart forms | ✗ | ✗ | ✓ | ✗ | ✓ |
+| License | proprietary | Apache 2 | BSD | MIT | GPL-3.0 |
+
+---
+
+## Features
+
+### Authentication and Access Control
+- **JWT authentication** — login, registration, token invalidation, session limits
+- **Organizations and RBAC** — multi-tenant support with Owner, Admin, Developer, and Explorer roles
+- **Per-project JWT secrets** — each project gets its own cryptographic signing secret; a token from one project is rejected by another
+- **Row-level security** — access control enforced at the database level via PostgreSQL roles
+
+### Database and REST APIs
+- **Instant REST APIs** — create a table, get full CRUD endpoints immediately via PostgREST
+- **Schema management** — create, rename, and delete tables and columns through the API or UI
+- **Index management** — add and remove database indexes without writing SQL
+- **Stored functions** — define and call PostgreSQL functions through a REST interface
+- **CSV and XLSX import** — upload a spreadsheet, Fluxend creates the table and API for you
+- **Table duplication** — clone an existing table structure in one call
+- **OpenAPI export** — auto-generated OpenAPI documentation for every project
+
+### Storage
+- **Multi-driver file storage** — S3, Backblaze B2, Dropbox, or local filesystem
+- **File containers** — organize files into named buckets
+- **Download endpoints** — serve files through the API with access control
+- **Database backups** — scheduled or on-demand PostgreSQL backups per project
+
+### Forms
+- **Smart forms** — create forms with typed fields and validation rules
+- **Form responses** — collect and query submissions through the API
+- **Field types** — text, number, boolean, and more
+
+### Observability
+- **Audit logs** — every API request to PostgREST endpoints is logged with user, method, status, and timestamp
+- **Database statistics** — table sizes, row counts, and index usage per project
+- **Health endpoint** — check container and database status across all projects
+
+### Developer Experience
+- **Self-contained Docker deployment** — Traefik, PostgreSQL, API, and frontend in one `docker compose up`
+- **CLI commands** — restart PostgREST instances, run migrations, seed settings from the command line
+- **Sentry integration** — error tracking built in, opt-in via environment variable
+- **CORS configuration** — per-deployment origin allowlist
+
+---
+
+## Quick Start
+
+**Requirements:** Docker, Docker Compose
+
+```bash
+git clone https://github.com/fluxend/fluxend.git
+cd fluxend
+cp .env.example .env   # fill in your values
+docker compose up -d
+```
+
+Open `http://console.yourdomain.com` and register the first user.
+
+Full setup guide: [docs.fluxend.app/quickstart](https://docs.fluxend.app/quickstart)
+
+---
+
+## How It Works
+
+```
+Your client app
+      │
+      ▼
+┌─────────────┐     ┌─────────────────────────────────────┐
+│  Fluxend    │     │  Per-project PostgREST containers   │
+│  API (Go)   │────▶│  Each signed with its own JWT secret│
+│             │     │  Routed by Traefik                  │
+└─────────────┘     └──────────────┬──────────────────────┘
+      │                            │
+      ▼                            ▼
+┌─────────────────────────────────────────────────────────┐
+│              PostgreSQL 17                              │
+│   fluxend schema (users, orgs, projects, settings)     │
+│   Per-project user databases (udb*)                    │
+└─────────────────────────────────────────────────────────┘
+```
+
+1. Users authenticate against the Fluxend API and receive a JWT.
+2. They create projects. Each project provisions a dedicated PostgreSQL database and a PostgREST container with its own signing secret.
+3. Clients call `GET /projects/:id/token` to get a project-scoped token.
+4. They use that token directly against the project's PostgREST URL for data access.
+5. Traefik routes traffic and handles TLS termination.
+
+---
+
+## API Overview
+
+| Resource | Endpoints |
+|---|---|
+| Users | register, login, logout, profile |
+| Organizations | CRUD, member management |
+| Projects | CRUD, token, OpenAPI, logs, stats |
+| Tables | CRUD, rename, duplicate, upload |
+| Columns | CRUD, rename |
+| Indexes | CRUD |
+| Functions | CRUD, invoke |
+| Storage containers | CRUD |
+| Files | upload, download, rename, delete |
+| Forms | CRUD |
+| Form fields | CRUD |
+| Form responses | CRUD |
+| Backups | create, list, delete |
+| Settings | list, update, reset |
+| Health | pulse |
+
+Full API reference: [docs.fluxend.app](https://docs.fluxend.app)
+
+---
+
+## Environment Variables
+
+| Variable | Description |
+|---|---|
+| `DATABASE_HOST` | PostgreSQL host |
+| `DATABASE_USER` | PostgreSQL user |
+| `DATABASE_PASSWORD` | PostgreSQL password |
+| `DATABASE_NAME` | PostgreSQL database name |
+| `JWT_SECRET` | Secret for signing console/auth tokens (min 32 chars) |
+| `BASE_DOMAIN` | Root domain for Traefik routing |
+| `URL_SCHEME` | `http` or `https` |
+| `POSTGREST_DB_USER` | PostgreSQL user for PostgREST connections |
+| `POSTGREST_DB_PASSWORD` | PostgreSQL password for PostgREST connections |
+| `POSTGREST_DB_HOST` | PostgreSQL host for PostgREST containers |
+| `POSTGREST_DEFAULT_SCHEMA` | Default schema exposed by PostgREST |
+| `POSTGREST_DEFAULT_ROLE` | Anonymous role for PostgREST |
+| `STORAGE_DRIVER` | `local`, `s3`, `backblaze`, or `dropbox` |
+| `CUSTOM_ORIGINS` | Comma-separated CORS allowed origins |
+| `SENTRY_DSN` | Optional Sentry DSN for error tracking |
+
+---
+
+## Use Cases
+
+**SaaS backends** — multi-tenant architecture with per-org projects and RBAC out of the box.
+
+**Internal tools** — spin up a data API from an existing PostgreSQL schema in minutes, no backend code required.
+
+**Rapid prototyping** — go from idea to working API in under five minutes. Replace Fluxend with a custom service later if you need to; your data stays in Postgres.
+
+**Data collection** — use the forms API to collect submissions from external sources without managing a backend.
+
+**Firebase or Supabase migration** — move off a vendor-hosted BaaS without rewriting your frontend. Fluxend speaks the same REST patterns.
+
+---
+
+## Tech Stack
+
+**Backend:** Go 1.23 · Echo v4 · sqlx · PostgreSQL 17 · PostgREST · samber/do (DI) · golang-jwt · AWS SDK v2 · zerolog · Sentry
+
+**Frontend:** React 19 · React Router 7 · TanStack Query · Tailwind CSS 4 · shadcn/ui · TypeScript
+
+**Infrastructure:** Docker · Docker Compose · Traefik v2 · goose (migrations)
+
+---
+
+## Contributing
+
+The codebase is organized as a standard Go project. Backend lives in `internal/`, frontend in `web/`.
+
+```bash
+# Run the test suite
+go test ./...
+
+# Run integration tests (requires local PostgreSQL)
+go test ./tests/integration/...
+
+# Build
+go build ./cmd/...
+```
+
+See [AGENTS.md](./AGENTS.md) for architecture notes and coding standards.
+
+- Check [open issues](https://github.com/fluxend/fluxend/issues) for things to work on
+- Open a PR — reviews are fast
+
+---
+
+## License
+
+GPL-3.0. See [LICENSE](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   <a href="https://docs.fluxend.app/">📚 Docs</a> •
   <a href="https://docs.fluxend.app/quickstart">⚡ Quick Start</a> •
   <a href="https://docs.fluxend.app/faq">❓ FAQ</a> •
+  <a href="https://docs.fluxend.app/development">🛠️ Development</a> •
   <a href="https://github.com/fluxend/fluxend/issues">🐛 Issues</a>
 </p>
 
@@ -117,51 +118,25 @@ Full setup guide: [docs.fluxend.app/quickstart](https://docs.fluxend.app/quickst
 
 ## How It Works
 
-```
-Your client app
-      │
-      ▼
-┌─────────────┐     ┌─────────────────────────────────────┐
-│  Fluxend    │     │  Per-project PostgREST containers   │
-│  API (Go)   │────▶│  Each signed with its own JWT secret│
-│             │     │  Routed by Traefik                  │
-└─────────────┘     └──────────────┬──────────────────────┘
-      │                            │
-      ▼                            ▼
-┌─────────────────────────────────────────────────────────┐
-│              PostgreSQL 17                              │
-│   fluxend schema (users, orgs, projects, settings)     │
-│   Per-project user databases (udb*)                    │
-└─────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    Client([Client app])
+
+    Client -->|"1. Authenticate"| API["Fluxend API (Go)"]
+    API -->|"2. Provision"| PG["Per-project PostgREST containers\nEach with its own JWT signing secret\nRouted by Traefik"]
+    API -->|"3. Return project-scoped token"| Client
+    Client -->|"4. Direct data access"| PG
+    API --- DB[("PostgreSQL 17\nfluxend schema · per-project databases")]
+    PG --- DB
 ```
 
 1. Users authenticate against the Fluxend API and receive a JWT.
-2. They create projects. Each project provisions a dedicated PostgreSQL database and a PostgREST container with its own signing secret.
+2. Each project provisions a dedicated PostgreSQL database and a PostgREST container with its own signing secret.
 3. Clients call `GET /projects/:id/token` to get a project-scoped token.
 4. They use that token directly against the project's PostgREST URL for data access.
 5. Traefik routes traffic and handles TLS termination.
 
 ---
-
-## API Overview
-
-| Resource | Endpoints |
-|---|---|
-| Users | register, login, logout, profile |
-| Organizations | CRUD, member management |
-| Projects | CRUD, token, OpenAPI, logs, stats |
-| Tables | CRUD, rename, duplicate, upload |
-| Columns | CRUD, rename |
-| Indexes | CRUD |
-| Functions | CRUD, invoke |
-| Storage containers | CRUD |
-| Files | upload, download, rename, delete |
-| Forms | CRUD |
-| Form fields | CRUD |
-| Form responses | CRUD |
-| Backups | create, list, delete |
-| Settings | list, update, reset |
-| Health | pulse |
 
 Full API reference: [docs.fluxend.app](https://docs.fluxend.app)
 
@@ -238,7 +213,7 @@ go test ./tests/integration/...
 go build ./cmd/...
 ```
 
-See [AGENTS.md](./AGENTS.md) for architecture notes and coding standards.
+See [AGENTS.md](./AGENTS.md) for architecture notes and coding standards, and [docs.fluxend.app/development](https://docs.fluxend.app/development) for the full development guide.
 
 - Check [open issues](https://github.com/fluxend/fluxend/issues) for things to work on
 - Open a PR. Reviews are fast.

--- a/internal/adapters/postgrest/service.go
+++ b/internal/adapters/postgrest/service.go
@@ -22,7 +22,6 @@ type Config struct {
 	DBHost        string
 	DBSchema      string
 	DBRole        string
-	JWTSecret     string
 	BaseDomain    string
 	CustomOrigins string
 	URLScheme     string
@@ -45,7 +44,6 @@ func NewPostgrestService(injector *do.Injector) (shared.PostgrestService, error)
 		DBHost:        os.Getenv("POSTGREST_DB_HOST"),
 		DBSchema:      os.Getenv("POSTGREST_DEFAULT_SCHEMA"),
 		DBRole:        os.Getenv("POSTGREST_DEFAULT_ROLE"),
-		JWTSecret:     os.Getenv("JWT_SECRET"),
 		BaseDomain:    os.Getenv("BASE_DOMAIN"),
 		URLScheme:     os.Getenv("URL_SCHEME"),
 		CustomOrigins: corsOrigins,
@@ -59,8 +57,8 @@ func NewPostgrestService(injector *do.Injector) (shared.PostgrestService, error)
 	}, nil
 }
 
-func (s *ServiceImpl) StartContainer(dbName string) {
-	if err := pkg.ExecuteCommand(s.buildStartCommand(dbName)); err != nil {
+func (s *ServiceImpl) StartContainer(dbName, jwtSecret string) {
+	if err := pkg.ExecuteCommand(s.buildStartCommand(dbName, jwtSecret)); err != nil {
 		log.Error().
 			Str("action", constants.ActionPostgrest).
 			Str("db", dbName).
@@ -145,14 +143,14 @@ func (s *ServiceImpl) HasContainer(dbName string) bool {
 	return strings.Contains(output, "true")
 }
 
-func (s *ServiceImpl) buildStartCommand(dbName string) []string {
+func (s *ServiceImpl) buildStartCommand(dbName, jwtSecret string) []string {
 	response := []string{
 		"docker", "run", "-d", "--name", s.getContainerName(dbName),
 		"--network", "fluxend_network",
 		"-e", fmt.Sprintf("PGRST_DB_URI=postgres://%s:%s@%s/%s", s.config.DBUser, s.config.DBPassword, s.config.DBHost, dbName),
 		"-e", "PGRST_DB_ANON_ROLE=" + s.config.DBRole,
 		"-e", "PGRST_DB_SCHEMA=" + s.config.DBSchema,
-		"-e", "PGRST_JWT_SECRET=" + s.config.JWTSecret,
+		"-e", "PGRST_JWT_SECRET=" + jwtSecret,
 		"-e", "PGRST_SERVER_CORS_ALLOWED_ORIGINS=" + s.config.CustomOrigins,
 		"-e", "PGRST_SERVER_CORS_ALLOWED_HEADERS=*",
 		"-e", "PGRST_SERVER_CORS_ALLOWED_METHODS=GET,POST,PATCH,PUT,DELETE,OPTIONS,HEAD",

--- a/internal/api/handlers/project.go
+++ b/internal/api/handlers/project.go
@@ -119,6 +119,46 @@ func (ph *ProjectHandler) Show(c echo.Context) error {
 	return response.SuccessResponse(c, mapper.ToProjectResource(&fetchedProject))
 }
 
+// Token returns a JWT signed with the project's secret for PostgREST access
+//
+// @Summary Get project token
+// @Description Get a JWT token signed with the project's signing secret for direct PostgREST access
+// @Tags Projects
+//
+// @Accept json
+// @Produce json
+//
+// @Param Authorization header string true "Bearer Token"
+// @Param projectUUID path string true "Project UUID"
+//
+// @Success 200 {object} response.Response "Project token"
+// @Failure 400 {object} response.BadRequestErrorResponse "Bad request response"
+// @Failure 401 {object} response.UnauthorizedErrorResponse "Unauthorized response"
+// @Failure 403 {object} response.ForbiddenErrorResponse "Forbidden response"
+// @Failure 500 {object} response.InternalServerErrorResponse "Internal server error response"
+//
+// @Router /projects/{projectUUID}/token [get]
+func (ph *ProjectHandler) Token(c echo.Context) error {
+	var request dto.DefaultRequest
+	if err := request.BindAndValidate(c); err != nil {
+		return response.UnprocessableResponse(c, err)
+	}
+
+	authUser, _ := auth.NewAuth(c).User()
+
+	projectUUID, err := request.GetUUIDPathParam(c, "projectUUID", true)
+	if err != nil {
+		return response.BadRequestResponse(c, err.Error())
+	}
+
+	token, err := ph.projectService.GetProjectToken(projectUUID, authUser)
+	if err != nil {
+		return response.ErrorResponse(c, err)
+	}
+
+	return response.SuccessResponse(c, map[string]string{"token": token})
+}
+
 // Store creates a new project
 //
 // @Summary Create project

--- a/internal/api/routes/project.go
+++ b/internal/api/routes/project.go
@@ -19,6 +19,7 @@ func RegisterProjectRoutes(e *echo.Echo, container *do.Injector, authMiddleware 
 	projectsGroup.DELETE("/:projectUUID", projectController.Delete)
 	projectsGroup.GET("/:projectUUID/openapi", projectController.GenerateOpenAPI)
 	projectsGroup.GET("/:projectUUID/logs", projectController.ListLogs)
+	projectsGroup.GET("/:projectUUID/token", projectController.Token)
 
 	projectsGroup.GET("/:projectUUID/stats", statHandler.Retrieve)
 

--- a/internal/app/commands/udb_restart.go
+++ b/internal/app/commands/udb_restart.go
@@ -51,7 +51,7 @@ func restartPostgrestInstances() error {
 			postgrestService.RemoveContainer(currentProject.DBName)
 		}
 
-		postgrestService.StartContainer(currentProject.DBName)
+		postgrestService.StartContainer(currentProject.DBName, currentProject.JWTSecret)
 	}
 
 	return nil

--- a/internal/database/migrations/20260628000000_add_jwt_secret_to_projects.sql
+++ b/internal/database/migrations/20260628000000_add_jwt_secret_to_projects.sql
@@ -1,0 +1,5 @@
+ALTER TABLE fluxend.projects ADD COLUMN IF NOT EXISTS jwt_secret TEXT NOT NULL DEFAULT '';
+
+UPDATE fluxend.projects SET jwt_secret = encode(gen_random_bytes(32), 'hex') WHERE jwt_secret = '';
+
+ALTER TABLE fluxend.projects ALTER COLUMN jwt_secret DROP DEFAULT;

--- a/internal/database/migrations/20260628000000_add_jwt_secret_to_projects.sql
+++ b/internal/database/migrations/20260628000000_add_jwt_secret_to_projects.sql
@@ -1,5 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
 ALTER TABLE fluxend.projects ADD COLUMN IF NOT EXISTS jwt_secret TEXT NOT NULL DEFAULT '';
-
 UPDATE fluxend.projects SET jwt_secret = encode(gen_random_bytes(32), 'hex') WHERE jwt_secret = '';
-
 ALTER TABLE fluxend.projects ALTER COLUMN jwt_secret DROP DEFAULT;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE fluxend.projects DROP COLUMN IF EXISTS jwt_secret;
+-- +goose StatementEnd

--- a/internal/database/migrations/20260628000000_add_jwt_secret_to_projects.sql
+++ b/internal/database/migrations/20260628000000_add_jwt_secret_to_projects.sql
@@ -1,7 +1,7 @@
 -- +goose Up
 -- +goose StatementBegin
 ALTER TABLE fluxend.projects ADD COLUMN IF NOT EXISTS jwt_secret TEXT NOT NULL DEFAULT '';
-UPDATE fluxend.projects SET jwt_secret = encode(gen_random_bytes(32), 'hex') WHERE jwt_secret = '';
+UPDATE fluxend.projects SET jwt_secret = replace(gen_random_uuid()::text, '-', '') || replace(gen_random_uuid()::text, '-', '') WHERE jwt_secret = '';
 ALTER TABLE fluxend.projects ALTER COLUMN jwt_secret DROP DEFAULT;
 -- +goose StatementEnd
 

--- a/internal/database/repositories/project.go
+++ b/internal/database/repositories/project.go
@@ -107,10 +107,10 @@ func (r *ProjectRepository) Create(project *project.Project) (*project.Project, 
 	return project, r.db.WithTransaction(func(tx shared.Tx) error {
 		query := `
 			INSERT INTO fluxend.projects (
-				name, db_name, description, db_port, 
-				organization_uuid, created_by, updated_by
-			) 
-			VALUES ($1, $2, $3, $4, $5, $6, $7) 
+				name, db_name, description, db_port,
+				organization_uuid, created_by, updated_by, jwt_secret
+			)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 			RETURNING uuid
 		`
 
@@ -123,6 +123,7 @@ func (r *ProjectRepository) Create(project *project.Project) (*project.Project, 
 			project.OrganizationUuid,
 			project.CreatedBy,
 			project.UpdatedBy,
+			project.JWTSecret,
 		).Scan(&project.Uuid)
 	})
 }

--- a/internal/domain/project/entity.go
+++ b/internal/domain/project/entity.go
@@ -17,6 +17,7 @@ type Project struct {
 	Description      string    `db:"description"`
 	DBName           string    `db:"db_name"`
 	DBPort           int       `db:"db_port"`
+	JWTSecret        string    `db:"jwt_secret"`
 	CreatedAt        time.Time `db:"created_at"`
 	UpdatedAt        time.Time `db:"updated_at"`
 }

--- a/internal/domain/project/service.go
+++ b/internal/domain/project/service.go
@@ -1,12 +1,15 @@
 package project
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fluxend/internal/domain/auth"
 	"fluxend/internal/domain/shared"
 	"fluxend/pkg/errors"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/samber/do"
-	"math/rand"
+	mathrand "math/rand"
 	"strings"
 	"time"
 )
@@ -15,6 +18,7 @@ type Service interface {
 	List(paginationParams shared.PaginationParams, organizationUUID uuid.UUID, authUser auth.User) ([]Project, error)
 	GetByUUID(projectUUID uuid.UUID, authUser auth.User) (Project, error)
 	GetDatabaseNameByUUID(projectUUID uuid.UUID, authUser auth.User) (string, error)
+	GetProjectToken(projectUUID uuid.UUID, authUser auth.User) (string, error)
 	Create(request *CreateProjectInput, authUser auth.User) (Project, error)
 	Update(projectUUID uuid.UUID, authUser auth.User, request *UpdateProjectInput) (*Project, error)
 	Delete(projectUUID uuid.UUID, authUser auth.User) (bool, error)
@@ -91,6 +95,7 @@ func (s *ServiceImpl) Create(request *CreateProjectInput, authUser auth.User) (P
 		OrganizationUuid: request.OrganizationUUID,
 		DBName:           s.generateDBName(),
 		DBPort:           s.generateDBPort(),
+		JWTSecret:        s.generateJWTSecret(),
 		CreatedBy:        authUser.Uuid,
 		UpdatedBy:        authUser.Uuid,
 	}
@@ -108,7 +113,7 @@ func (s *ServiceImpl) Create(request *CreateProjectInput, authUser auth.User) (P
 		return Project{}, err
 	}
 
-	go s.postgrestService.StartContainer(projectInput.DBName)
+	go s.postgrestService.StartContainer(projectInput.DBName, projectInput.JWTSecret)
 
 	return projectInput, nil
 }
@@ -161,7 +166,35 @@ func (s *ServiceImpl) generateDBName() string {
 }
 
 func (s *ServiceImpl) generateDBPort() int {
-	return rand.Intn(65535-5000+1) + 5000
+	return mathrand.Intn(65535-5000+1) + 5000
+}
+
+func (s *ServiceImpl) generateJWTSecret() string {
+	b := make([]byte, 32)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+func (s *ServiceImpl) GetProjectToken(projectUUID uuid.UUID, authUser auth.User) (string, error) {
+	fetchedProject, err := s.projectRepo.GetByUUID(projectUUID)
+	if err != nil {
+		return "", err
+	}
+
+	if !s.projectPolicy.CanAccess(fetchedProject.OrganizationUuid, authUser) {
+		return "", errors.NewForbiddenError("project.error.viewForbidden")
+	}
+
+	role := "usr_" + strings.ReplaceAll(authUser.Uuid.String(), "-", "_")
+	claims := jwt.MapClaims{
+		"role": role,
+		"exp":  time.Now().Add(time.Hour * 24).Unix(),
+		"iat":  time.Now().Unix(),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+
+	return token.SignedString([]byte(fetchedProject.JWTSecret))
 }
 
 func (s *ServiceImpl) validateNameForDuplication(name string, organizationUUID uuid.UUID) error {

--- a/internal/domain/project/service_test.go
+++ b/internal/domain/project/service_test.go
@@ -1,0 +1,201 @@
+package project
+
+import (
+	"errors"
+	"fluxend/internal/config/constants"
+	"fluxend/internal/domain/auth"
+	"fluxend/internal/domain/shared"
+	"fluxend/tests/fixtures/mocks/organization"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+)
+
+// stubProjectRepo is a minimal testify mock covering only what GetProjectToken calls.
+// Using an inline mock here avoids the import cycle that would arise from importing
+// tests/fixtures/mocks/project (which itself imports this package).
+type stubProjectRepo struct {
+	mock.Mock
+}
+
+func (m *stubProjectRepo) GetByUUID(projectUUID uuid.UUID) (Project, error) {
+	args := m.Called(projectUUID)
+	return args.Get(0).(Project), args.Error(1)
+}
+
+func (m *stubProjectRepo) ListForUser(p shared.PaginationParams, userID uuid.UUID) ([]Project, error) {
+	panic("not expected")
+}
+func (m *stubProjectRepo) List(p shared.PaginationParams) ([]Project, error) { panic("not expected") }
+func (m *stubProjectRepo) GetDatabaseNameByUUID(id uuid.UUID) (string, error) {
+	panic("not expected")
+}
+func (m *stubProjectRepo) GetUUIDByDatabaseName(dbName string) (uuid.UUID, error) {
+	panic("not expected")
+}
+func (m *stubProjectRepo) GetOrganizationUUIDByProjectUUID(id uuid.UUID) (uuid.UUID, error) {
+	panic("not expected")
+}
+func (m *stubProjectRepo) ExistsByUUID(id uuid.UUID) (bool, error)      { panic("not expected") }
+func (m *stubProjectRepo) ExistsByNameForOrganization(name string, orgUUID uuid.UUID) (bool, error) {
+	panic("not expected")
+}
+func (m *stubProjectRepo) Create(p *Project) (*Project, error)                { panic("not expected") }
+func (m *stubProjectRepo) Update(p *Project) (*Project, error)                { panic("not expected") }
+func (m *stubProjectRepo) UpdateStatusByDatabaseName(db, status string) (bool, error) {
+	panic("not expected")
+}
+func (m *stubProjectRepo) Delete(id uuid.UUID) (bool, error) { panic("not expected") }
+
+func buildServiceForTokenTests(t *testing.T) (*ServiceImpl, *stubProjectRepo, *organization.MockRepository) {
+	projectRepo := &stubProjectRepo{}
+	orgRepo := organization.NewMockRepository(t)
+	policy := &Policy{organizationRepo: orgRepo}
+
+	svc := &ServiceImpl{
+		projectPolicy: policy,
+		projectRepo:   projectRepo,
+	}
+
+	return svc, projectRepo, orgRepo
+}
+
+func TestGetProjectToken_Suite(t *testing.T) {
+	t.Run("returns error when project not found", func(t *testing.T) {
+		svc, projectRepo, _ := buildServiceForTokenTests(t)
+
+		projectUUID := uuid.New()
+		authUser := auth.User{Uuid: uuid.New(), RoleID: constants.UserRoleDeveloper}
+
+		projectRepo.On("GetByUUID", projectUUID).Return(Project{}, errors.New("project.error.notFound"))
+
+		_, err := svc.GetProjectToken(projectUUID, authUser)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "notFound")
+	})
+
+	t.Run("returns forbidden when user is not an org member", func(t *testing.T) {
+		svc, projectRepo, orgRepo := buildServiceForTokenTests(t)
+
+		orgUUID := uuid.New()
+		projectUUID := uuid.New()
+		authUser := auth.User{Uuid: uuid.New(), RoleID: constants.UserRoleDeveloper}
+
+		projectRepo.On("GetByUUID", projectUUID).Return(Project{
+			Uuid:             projectUUID,
+			OrganizationUuid: orgUUID,
+			JWTSecret:        "somesecret",
+		}, nil)
+		orgRepo.On("IsOrganizationMember", orgUUID, authUser.Uuid).Return(false, nil)
+
+		_, err := svc.GetProjectToken(projectUUID, authUser)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "viewForbidden")
+	})
+
+	t.Run("returned token is verifiable with the project's own secret", func(t *testing.T) {
+		svc, projectRepo, orgRepo := buildServiceForTokenTests(t)
+
+		orgUUID := uuid.New()
+		projectUUID := uuid.New()
+		userUUID := uuid.New()
+		authUser := auth.User{Uuid: userUUID, RoleID: constants.UserRoleDeveloper}
+		projectSecret := "a-distinct-per-project-secret-that-is-long-enough"
+
+		projectRepo.On("GetByUUID", projectUUID).Return(Project{
+			Uuid:             projectUUID,
+			OrganizationUuid: orgUUID,
+			JWTSecret:        projectSecret,
+		}, nil)
+		orgRepo.On("IsOrganizationMember", orgUUID, userUUID).Return(true, nil)
+
+		tokenString, err := svc.GetProjectToken(projectUUID, authUser)
+
+		require.NoError(t, err)
+		require.NotEmpty(t, tokenString)
+
+		claims := jwt.MapClaims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(projectSecret), nil
+		})
+		require.NoError(t, err)
+		assert.True(t, token.Valid)
+
+		expectedRole := "usr_" + strings.ReplaceAll(userUUID.String(), "-", "_")
+		assert.Equal(t, expectedRole, claims["role"])
+	})
+
+	t.Run("token does not verify against the global JWT_SECRET", func(t *testing.T) {
+		svc, projectRepo, orgRepo := buildServiceForTokenTests(t)
+
+		orgUUID := uuid.New()
+		projectUUID := uuid.New()
+		userUUID := uuid.New()
+		authUser := auth.User{Uuid: userUUID, RoleID: constants.UserRoleDeveloper}
+
+		projectRepo.On("GetByUUID", projectUUID).Return(Project{
+			Uuid:             projectUUID,
+			OrganizationUuid: orgUUID,
+			JWTSecret:        "per-project-secret-distinct-from-global-one-xxxxxxxx",
+		}, nil)
+		orgRepo.On("IsOrganizationMember", orgUUID, userUUID).Return(true, nil)
+
+		tokenString, err := svc.GetProjectToken(projectUUID, authUser)
+		require.NoError(t, err)
+
+		claims := jwt.MapClaims{}
+		_, err = jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte("test_jwt_secret_key_that_is_long_enough_for_validation"), nil
+		})
+		assert.Error(t, err, "token signed with project secret must not verify against global JWT_SECRET")
+	})
+
+	t.Run("token from project A is rejected by project B's secret", func(t *testing.T) {
+		svc, projectRepo, orgRepo := buildServiceForTokenTests(t)
+
+		orgUUID := uuid.New()
+		userUUID := uuid.New()
+		authUser := auth.User{Uuid: userUUID, RoleID: constants.UserRoleDeveloper}
+
+		projectAUUID := uuid.New()
+		secretA := "secret-for-project-alpha-long-enough-aaaaaaaaaaaaa"
+		projectBUUID := uuid.New()
+		secretB := "secret-for-project-beta-long-enough-bbbbbbbbbbbbb"
+
+		projectRepo.On("GetByUUID", projectAUUID).Return(Project{
+			Uuid:             projectAUUID,
+			OrganizationUuid: orgUUID,
+			JWTSecret:        secretA,
+		}, nil)
+		projectRepo.On("GetByUUID", projectBUUID).Return(Project{
+			Uuid:             projectBUUID,
+			OrganizationUuid: orgUUID,
+			JWTSecret:        secretB,
+		}, nil)
+		orgRepo.On("IsOrganizationMember", orgUUID, userUUID).Return(true, nil).Times(2)
+
+		tokenA, err := svc.GetProjectToken(projectAUUID, authUser)
+		require.NoError(t, err)
+
+		tokenB, err := svc.GetProjectToken(projectBUUID, authUser)
+		require.NoError(t, err)
+
+		claims := jwt.MapClaims{}
+
+		_, err = jwt.ParseWithClaims(tokenA, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(secretB), nil
+		})
+		assert.Error(t, err, "project A token must not verify against project B secret")
+
+		_, err = jwt.ParseWithClaims(tokenB, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(secretA), nil
+		})
+		assert.Error(t, err, "project B token must not verify against project A secret")
+	})
+}

--- a/internal/domain/shared/postgrest_service.go
+++ b/internal/domain/shared/postgrest_service.go
@@ -1,7 +1,7 @@
 package shared
 
 type PostgrestService interface {
-	StartContainer(dbName string)
+	StartContainer(dbName, jwtSecret string)
 	RemoveContainer(dbName string)
 	HasContainer(dbName string) bool
 	RefreshSchemaCache(dbName string)

--- a/tests/integration/api/projects_token_test.go
+++ b/tests/integration/api/projects_token_test.go
@@ -68,7 +68,7 @@ func TestProjectToken_Suite(t *testing.T) {
 	authToken := registeredUser.Content.Token
 
 	// Create an organization
-	orgInput := map[string]string{"name": pkg.Faker.Company().Name()}
+	orgInput := map[string]string{"name": "test-org-" + pkg.Faker.RandomStringWithLength(6)}
 	orgResp := server.PostJSONWithAuth(t, "/organizations", authToken, orgInput)
 	defer orgResp.Body.Close()
 	require.Equal(t, http.StatusCreated, orgResp.StatusCode)

--- a/tests/integration/api/projects_token_test.go
+++ b/tests/integration/api/projects_token_test.go
@@ -1,0 +1,176 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	organizationDto "fluxend/internal/api/dto/organization"
+	"fluxend/pkg"
+	"fluxend/tests/integration"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type projectTokenResponse struct {
+	integration.APIResponse
+	Content struct {
+		Token string `json:"token"`
+	} `json:"content"`
+}
+
+type organizationResponse struct {
+	integration.APIResponse
+	Content organizationDto.Response `json:"content"`
+}
+
+// seedProjectWithSecret inserts a project row directly into the DB with a known jwt_secret,
+// bypassing the Docker container provisioning that the API endpoint would trigger.
+func seedProjectWithSecret(t *testing.T, server *integration.TestServer, orgUUID, userUUID uuid.UUID, jwtSecret string) uuid.UUID {
+	t.Helper()
+
+	var projectUUID uuid.UUID
+	err := server.DB.QueryRow(`
+		INSERT INTO fluxend.projects (name, db_name, description, db_port, organization_uuid, created_by, updated_by, jwt_secret)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		RETURNING uuid`,
+		pkg.Faker.RandomStringWithLength(10),
+		"udb"+strings.ReplaceAll(uuid.New().String(), "-", ""),
+		"test project",
+		pkg.Faker.IntBetween(20000, 40000),
+		orgUUID,
+		userUUID,
+		userUUID,
+		jwtSecret,
+	).Scan(&projectUUID)
+	require.NoError(t, err)
+
+	return projectUUID
+}
+
+func TestProjectToken_Suite(t *testing.T) {
+	server := integration.NewTestServer()
+	defer server.Close()
+
+	// Register a user
+	userInput := getFakeUserData()
+	registerResp := server.PostJSON(t, "/users/register", userInput)
+	defer registerResp.Body.Close()
+	require.Equal(t, http.StatusCreated, registerResp.StatusCode)
+
+	var registeredUser userResponse
+	require.NoError(t, json.NewDecoder(registerResp.Body).Decode(&registeredUser))
+	userUUID, _ := uuid.Parse(registeredUser.Content.User.Uuid.String())
+	authToken := registeredUser.Content.Token
+
+	// Create an organization
+	orgInput := map[string]string{"name": pkg.Faker.Company().Name()}
+	orgResp := server.PostJSONWithAuth(t, "/organizations", authToken, orgInput)
+	defer orgResp.Body.Close()
+	require.Equal(t, http.StatusCreated, orgResp.StatusCode)
+
+	var org organizationResponse
+	require.NoError(t, json.NewDecoder(orgResp.Body).Decode(&org))
+	orgUUID := org.Content.Uuid
+
+	// Seed two projects with distinct known secrets
+	secretA := "integration-test-secret-for-project-alpha-aaaaaaaa"
+	secretB := "integration-test-secret-for-project-beta-bbbbbbbbb"
+	projectAUUID := seedProjectWithSecret(t, server, orgUUID, userUUID, secretA)
+	projectBUUID := seedProjectWithSecret(t, server, orgUUID, userUUID, secretB)
+
+	server.AddCleanup(func() error {
+		server.DB.Exec("DELETE FROM fluxend.projects WHERE uuid IN ($1, $2)", projectAUUID, projectBUUID)
+		server.DB.Exec("DELETE FROM fluxend.organizations WHERE uuid = $1", orgUUID)
+		return server.CleanupUser(userUUID)
+	})
+
+	t.Run("unauthenticated request returns 401", func(t *testing.T) {
+		req, err := http.NewRequest("GET", server.BaseURL+fmt.Sprintf("/projects/%s/token", projectAUUID), nil)
+		require.NoError(t, err)
+
+		resp, err := server.Client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("unknown project UUID returns 404", func(t *testing.T) {
+		resp := server.GetWithAuth(t, fmt.Sprintf("/projects/%s/token", uuid.New()), authToken)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+
+	t.Run("member receives a valid signed token", func(t *testing.T) {
+		resp := server.GetWithAuth(t, fmt.Sprintf("/projects/%s/token", projectAUUID), authToken)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var tokenResp projectTokenResponse
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&tokenResp))
+		assert.True(t, tokenResp.Success)
+		require.NotEmpty(t, tokenResp.Content.Token)
+
+		// Token must parse and verify with the project's own secret
+		claims := jwt.MapClaims{}
+		token, err := jwt.ParseWithClaims(tokenResp.Content.Token, claims, func(t *jwt.Token) (interface{}, error) {
+			return []byte(secretA), nil
+		})
+		require.NoError(t, err)
+		assert.True(t, token.Valid)
+
+		// Role claim must match the user's PostgREST role
+		expectedRole := "usr_" + strings.ReplaceAll(userUUID.String(), "-", "_")
+		assert.Equal(t, expectedRole, claims["role"])
+	})
+
+	t.Run("token is not valid against the global JWT_SECRET", func(t *testing.T) {
+		resp := server.GetWithAuth(t, fmt.Sprintf("/projects/%s/token", projectAUUID), authToken)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var tokenResp projectTokenResponse
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&tokenResp))
+
+		claims := jwt.MapClaims{}
+		_, err := jwt.ParseWithClaims(tokenResp.Content.Token, claims, func(t *jwt.Token) (interface{}, error) {
+			return []byte("test_jwt_secret_key_that_is_long_enough_for_validation"), nil
+		})
+		assert.Error(t, err, "project token must not be verifiable with the global JWT_SECRET")
+	})
+
+	t.Run("project A token is rejected by project B's secret", func(t *testing.T) {
+		respA := server.GetWithAuth(t, fmt.Sprintf("/projects/%s/token", projectAUUID), authToken)
+		defer respA.Body.Close()
+		require.Equal(t, http.StatusOK, respA.StatusCode)
+
+		var tokenRespA projectTokenResponse
+		require.NoError(t, json.NewDecoder(respA.Body).Decode(&tokenRespA))
+
+		respB := server.GetWithAuth(t, fmt.Sprintf("/projects/%s/token", projectBUUID), authToken)
+		defer respB.Body.Close()
+		require.Equal(t, http.StatusOK, respB.StatusCode)
+
+		var tokenRespB projectTokenResponse
+		require.NoError(t, json.NewDecoder(respB.Body).Decode(&tokenRespB))
+
+		claims := jwt.MapClaims{}
+
+		_, err := jwt.ParseWithClaims(tokenRespA.Content.Token, claims, func(t *jwt.Token) (interface{}, error) {
+			return []byte(secretB), nil
+		})
+		assert.Error(t, err, "project A token must not verify against project B secret")
+
+		_, err = jwt.ParseWithClaims(tokenRespB.Content.Token, claims, func(t *jwt.Token) (interface{}, error) {
+			return []byte(secretA), nil
+		})
+		assert.Error(t, err, "project B token must not verify against project A secret")
+	})
+}

--- a/tests/integration/base.go
+++ b/tests/integration/base.go
@@ -124,6 +124,21 @@ func (ts *TestServer) PutJSONWithAuth(t *testing.T, endpoint, token string, data
 	return resp
 }
 
+func (ts *TestServer) PostJSONWithAuth(t *testing.T, endpoint, token string, data interface{}) *http.Response {
+	jsonData, err := json.Marshal(data)
+	assert.NoError(t, err, "Failed to marshal JSON data")
+
+	req, err := http.NewRequest("POST", ts.BaseURL+endpoint, bytes.NewBuffer(jsonData))
+	assert.NoError(t, err, "Failed to create POST request")
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := ts.Client.Do(req)
+	assert.NoError(t, err, "Failed to send POST request")
+
+	return resp
+}
+
 func (ts *TestServer) PostWithAuth(t *testing.T, endpoint, token string) *http.Response {
 	req, err := http.NewRequest("POST", ts.BaseURL+endpoint, nil)
 	assert.NoError(t, err, "Failed to create POST request")


### PR DESCRIPTION
## What

Every PostgREST container was started with the same global `JWT_SECRET`, meaning a token minted for one project was structurally valid against any other project's data API. Tenant isolation relied entirely on Postgres roles — a single misconfiguration could expose cross-tenant data.

Each project now gets its own cryptographic JWT signing secret generated at provision time. A token issued for project A is cryptographically rejected by project B's PostgREST.

## Changes

- Migration adds `jwt_secret TEXT NOT NULL` to `fluxend.projects`, backfilling existing rows with `encode(gen_random_bytes(32), 'hex')`
- Project service generates a 32-byte random secret per project on creation and stores it on the project row
- `StartContainer` now takes the per-project secret instead of reading the global `JWT_SECRET`
- `udb.restart` command passes each project's stored secret when restarting containers
- New `GET /projects/:projectUUID/token` endpoint returns a short-lived JWT signed with the project's secret, scoped to PostgREST access only (role claim, no Fluxend session data)
- Global `JWT_SECRET` is untouched — it still signs console/API tokens

## How to test

**Migration (existing deployments)**

Run migrations — existing projects will be backfilled with unique secrets automatically. Then restart their containers so PostgREST picks up the new secrets:

```
./fluxend udb.restart
```

**New projects**

Create a project normally. The provisioned PostgREST container will use a unique secret from the start.

**Endpoint**

```bash
# Get a project-scoped token
curl -H "Authorization: Bearer <console-token>" \
  https://api.<domain>/projects/<project-uuid>/token

# Use it against PostgREST directly
curl -H "Authorization: Bearer <project-token>" \
  https://<db-name>.<domain>/your_table
```

**Isolation check**

Fetch tokens for two different projects and confirm each token is rejected by the other project's PostgREST instance — a 401 from PostgREST on the wrong project confirms isolation is working.

**Automated tests**

```bash
# Unit tests (no DB needed)
go test ./internal/domain/project/...

# Integration tests (requires local DB)
go test ./tests/integration/...
```